### PR TITLE
Provider: add interface for abstract provider, basic types

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build:provider": "turbo run build --scope=*provider* --no-deps",
     "build:relayer": "turbo run build --scope=@pokt-foundation/relayer --no-deps",
     "build:txs": "turbo run build --scope=*transaction* --no-deps",
+    "build:types": "turbo run build --scope=*types* --no-deps",
     "build:utils": "turbo run build --scope=*utils* --no-deps",
     "dev": "turbo run dev --parallel",
     "dev:all": "turbo run dev --parallel --no-cache",
@@ -15,6 +16,7 @@
     "dev:pocket": "turbo run dev --scope=@pokt-foundation/pocketjs --no-cache --no-deps",
     "dev:provider": "turbo run dev --scope=*provider* --no-cache --no-deps",
     "dev:txs": "turbo run dev --scope=*transaction* --no-deps",
+    "dev:types": "turbo run dev --scope=*types* --no-cache --no-deps",
     "dev:utils": "turbo run dev --scope=*utils* --no-cache --no-deps",
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\""

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@pokt-foundation/pocketjs-types": "^0.0.0",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -1,27 +1,12 @@
-/* eslint-disable @typescript-eslint/no-empty-interface */
-export interface TransactionResponse {
-  code?: BigInt
-  codeSpace?: string
-  data?: string
-  hash: string
-  height: BigInt
-  info?: string
-  rawLog?: string
-  timestamp?: string
-  tx?: string
-}
-
-export interface Block {}
-
-export interface GetNodesOptions {}
-
-export interface GetAppOptions {}
-
-export interface App {}
-
-export interface Account {}
-
-export type AccountWithTransactions = Account
+import {
+  Account,
+  AccountWithTransactions,
+  App,
+  Block,
+  GetAppOptions,
+  GetNodesOptions,
+  TransactionResponse,
+} from '@pokt-foundation/pocketjs-types'
 
 export abstract class AbstractProvider {
   // Account

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+export interface TransactionResponse {
+  code?: BigInt
+  codeSpace?: string
+  data?: string
+  hash: string
+  height: BigInt
+  info?: string
+  rawLog?: string
+  timestamp?: string
+  tx?: string
+}
+
+export interface Block {}
+
+export interface GetNodesOptions {}
+
+export interface GetAppOptions {}
+
+export interface App {}
+
+export interface Account {}
+
+export type AccountWithTransactions = Account
+
+export abstract class AbstractProvider {
+  // Account
+  abstract getNetwork(): Promise<string> // mainnet or testnet
+  abstract getBalance(address: string | Promise<string>): Promise<bigint>
+  abstract getTransactionCount(
+    address: string | Promise<string>
+  ): Promise<number>
+  abstract getType(
+    address: string | Promise<string>
+  ): Promise<'node' | 'app' | 'account'>
+  // Txs
+  abstract sendTransaction(
+    signedTransaction: string | Promise<string>
+  ): Promise<TransactionResponse>
+  // Network
+  abstract getBlock(blockHash: string): Promise<Block>
+  abstract getBlock(blockNumber: number): Promise<Block>
+  abstract getBlockWithTransactions(blockHash: string): Promise<Block>
+  abstract getBlockWithTransactions(blockHeight: number): Promise<Block>
+  abstract getTransaction(transactionHash: string): Promise<TransactionResponse>
+  abstract getBlockNumber(): Promise<number>
+  abstract getNodes(getNodesOptions: GetNodesOptions): Promise<Node[]>
+  abstract getNode(
+    address: string | Promise<string>,
+    GetNodeOptions
+  ): Promise<Node>
+  abstract getApps(getAppOption: GetAppOptions): Promise<App[]>
+  abstract getApp(
+    address: string | Promise<string>,
+    GetAppOptions
+  ): Promise<App>
+  abstract getAccount(address: string | Promise<string>): Promise<Account>
+  abstract getAccountWithTransactions(
+    address: string | Promise<string>
+  ): Promise<AccountWithTransactions>
+
+  // TODO: Add methods for params/requestChallenge
+}

--- a/packages/provider/tsconfig.json
+++ b/packages/provider/tsconfig.json
@@ -3,7 +3,9 @@
   "display": "Default",
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "baseUrl": "."
+    "baseUrl": ".",
+    "composite": true
   },
+  "references": [{ "path": "../types" }],
   "exclude": ["node_modules"]
 }

--- a/packages/types/.eslintrc.json
+++ b/packages/types/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended"
+  ]
+}

--- a/packages/types/.prettierrc.json
+++ b/packages/types/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "trailingComma": "es5",
+  "tabWidth": 2,
+  "semi": false,
+  "singleQuote": true,
+  "arrowParens": "always"
+}

--- a/packages/types/jest.config.js
+++ b/packages/types/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+export default {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+}

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "PocketJS types",
   "type": "module",
-  "source": "src/index.ts",
+  "source": "src/index.d.ts",
   "exports": {
     "require": "./dist/index.cjs",
     "default": "./dist/index.js"
@@ -15,7 +15,7 @@
     "build": "microbundle",
     "dev": "microbundle watch"
   },
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pokt-foundation/pocketjs-types",
+  "version": "0.0.0",
+  "description": "PocketJS types",
+  "type": "module",
+  "source": "src/index.ts",
+  "exports": {
+    "require": "./dist/index.cjs",
+    "default": "./dist/index.js"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "unpkg": "./dist/index.umd.js",
+  "scripts": {
+    "build": "microbundle",
+    "dev": "microbundle watch"
+  },
+  "types": "dist/index.d.ts",
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "devDependencies": {
+    "@types/jest": "^27.4.0",
+    "@typescript-eslint/eslint-plugin": "^5.10.2",
+    "@typescript-eslint/parser": "^5.10.2",
+    "eslint": "7.32.0",
+    "jest": "^27.4.7",
+    "microbundle": "^0.14.2",
+    "prettier": "^2.5.1",
+    "prettier-eslint": "^13.0.0",
+    "ts-jest": "^27.1.3"
+  }
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,0 +1,24 @@
+/* eslint-disable @typescript-eslint/no-empty-interface */
+export interface TransactionResponse {
+  code?: BigInt
+  codeSpace?: string
+  data?: string
+  hash: string
+  height: BigInt
+  info?: string
+  rawLog?: string
+  timestamp?: string
+  tx?: string
+}
+
+export interface Block {}
+
+export interface GetNodesOptions {}
+
+export interface GetAppOptions {}
+
+export interface App {}
+
+export interface Account {}
+
+export type AccountWithTransactions = Account

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "display": "Default",
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "allowJs": true,
+    "composite": true
+  },
+  "references": [
+    { "path": "../utils" },
+    { "path": "../keybase" },
+    { "path": "../provider" }
+  ],
+  "exclude": ["node_modules", "dist", "jest.config.js"]
+}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -5,12 +5,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "allowJs": true,
-    "composite": true
+    "composite": true,
+    "declaration": true
   },
-  "references": [
-    { "path": "../utils" },
-    { "path": "../keybase" },
-    { "path": "../provider" }
-  ],
+  "references": [],
   "exclude": ["node_modules", "dist", "jest.config.js"]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,28 @@ importers:
       prettier-eslint: 13.0.0
       ts-jest: 27.1.3_a7e53b5e5b59e71a0fd4d8cf128393d5
 
+  packages/types:
+    specifiers:
+      '@types/jest': ^27.4.0
+      '@typescript-eslint/eslint-plugin': ^5.10.2
+      '@typescript-eslint/parser': ^5.10.2
+      eslint: 7.32.0
+      jest: ^27.4.7
+      microbundle: ^0.14.2
+      prettier: ^2.5.1
+      prettier-eslint: ^13.0.0
+      ts-jest: ^27.1.3
+    devDependencies:
+      '@types/jest': 27.4.0
+      '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f
+      '@typescript-eslint/parser': 5.10.2_eslint@7.32.0+typescript@4.5.5
+      eslint: 7.32.0
+      jest: 27.4.7
+      microbundle: 0.14.2
+      prettier: 2.5.1
+      prettier-eslint: 13.0.0
+      ts-jest: 27.1.3_a7e53b5e5b59e71a0fd4d8cf128393d5
+
   packages/utils:
     specifiers:
       '@types/jest': ^27.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,7 @@ importers:
 
   packages/provider:
     specifiers:
+      '@pokt-foundation/pocketjs-types': ^0.0.0
       '@types/jest': ^27.4.0
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
@@ -71,6 +72,7 @@ importers:
       ts-jest: ^27.1.3
       typescript: ^4.5.5
     devDependencies:
+      '@pokt-foundation/pocketjs-types': link:../types
       '@types/jest': 27.4.0
       '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f
       '@typescript-eslint/parser': 5.10.2_eslint@7.32.0+typescript@4.5.5

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
       "@pokt-foundation/pocketjs": ["packages/pocket"],
       "@pokt-foundation/pocketjs-keybase": ["packages/keybase"],
       "@pokt-foundation/pocketjs-provider": ["packages/provider"],
+      "@pokt-foundation/pocketjs-types": ["packages/types"],
       "@pokt-foundation/pocketjs-utils": ["packages/utils"]
     }
   }


### PR DESCRIPTION
Adds the first interface needed—the one for the abstract provider. Also adds a types package that will be used to dump types and possibly proto models.