### PR TITLE
Provider: Add JSON-RPC Provider

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -18,7 +18,7 @@
   "types": "dist/index.d.ts",
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "devDependencies": {
     "@pokt-foundation/pocketjs-types": "^0.0.0",
     "@types/jest": "^27.4.0",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -30,5 +30,8 @@
     "prettier": "^2.5.1",
     "ts-jest": "^27.1.3",
     "typescript": "^4.5.5"
+  },
+  "dependencies": {
+    "isomorphic-unfetch": "^3.1.0"
   }
 }

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -11,7 +11,6 @@ import {
 
 export abstract class AbstractProvider {
   // Account
-  abstract getNetwork(): Promise<string> // mainnet or testnet
   abstract getBalance(address: string | Promise<string>): Promise<bigint>
   abstract getTransactionCount(
     address: string | Promise<string>
@@ -25,7 +24,6 @@ export abstract class AbstractProvider {
   ): Promise<TransactionResponse>
   // Network
   abstract getBlock(blockNumber: number): Promise<Block>
-  abstract getBlockWithTransactions(blockHeight: number): Promise<Block>
   abstract getTransaction(transactionHash: string): Promise<TransactionResponse>
   abstract getBlockNumber(): Promise<number>
   abstract getNodes(getNodesOptions: GetNodesOptions): Promise<Node[]>

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -23,9 +23,7 @@ export abstract class AbstractProvider {
     signedTransaction: string | Promise<string>
   ): Promise<TransactionResponse>
   // Network
-  abstract getBlock(blockHash: string): Promise<Block>
   abstract getBlock(blockNumber: number): Promise<Block>
-  abstract getBlockWithTransactions(blockHash: string): Promise<Block>
   abstract getBlockWithTransactions(blockHeight: number): Promise<Block>
   abstract getTransaction(transactionHash: string): Promise<TransactionResponse>
   abstract getBlockNumber(): Promise<number>

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -30,12 +30,12 @@ export abstract class AbstractProvider {
   abstract getNodes(getNodesOptions: GetNodesOptions): Promise<Node[]>
   abstract getNode(
     address: string | Promise<string>,
-    GetNodeOptions
+    options: GetNodesOptions
   ): Promise<Node>
   abstract getApps(getAppOption: GetAppOptions): Promise<App[]>
   abstract getApp(
     address: string | Promise<string>,
-    GetAppOptions
+    options: GetAppOptions
   ): Promise<App>
   abstract getAccount(address: string | Promise<string>): Promise<Account>
   abstract getAccountWithTransactions(

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -20,6 +20,7 @@ export abstract class AbstractProvider {
   ): Promise<'node' | 'app' | 'account'>
   // Txs
   abstract sendTransaction(
+    signerAddress: string | Promise<string>,
     signedTransaction: string | Promise<string>
   ): Promise<TransactionResponse>
   // Network

--- a/packages/provider/src/abstract-provider.ts
+++ b/packages/provider/src/abstract-provider.ts
@@ -5,6 +5,7 @@ import {
   Block,
   GetAppOptions,
   GetNodesOptions,
+  Node,
   TransactionResponse,
 } from '@pokt-foundation/pocketjs-types'
 

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,5 +1,3 @@
-export class Provider {
-  public static gm() {
-    console.log('gm')
-  }
-}
+export * from './abstract-provider'
+export * from './json-rpc-provider'
+export * from './routes'

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -1,3 +1,4 @@
+import fetch from 'isomorphic-unfetch'
 import {
   Account,
   AccountWithTransactions,
@@ -8,17 +9,48 @@ import {
   TransactionResponse,
 } from '@pokt-foundation/pocketjs-types'
 import { AbstractProvider } from './abstract-provider'
+import { V1RpcRoutes } from './routes'
 
 export class JsonRpcProvider implements AbstractProvider {
+  private rpcUrl: string
+
+  constructor({ rpcUrl = '' }: { rpcUrl: string }) {
+    this.rpcUrl = rpcUrl
+  }
+
   getNetwork(): Promise<string> {
     throw new Error('Not implemented')
   }
-  getBalance(address: string | Promise<string>): Promise<bigint> {
-    throw new Error('Not implemented')
+
+  private perform({
+    route,
+    body,
+  }: {
+    route: V1RpcRoutes
+    body: any
+  }): Promise<Response> {
+    return fetch(`${this.rpcUrl}${route}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    })
   }
+
+  async getBalance(address: string | Promise<string>): Promise<bigint> {
+    const res = await this.perform({
+      route: V1RpcRoutes.QueryBalance,
+      body: { address: await address },
+    })
+    const { balance } = await res.json()
+    return balance as bigint
+  }
+
   getTransactionCount(address: string | Promise<string>): Promise<number> {
     throw new Error('Not implemented')
   }
+
   getType(
     address: string | Promise<string>
   ): Promise<'node' | 'app' | 'account'> {
@@ -31,34 +63,85 @@ export class JsonRpcProvider implements AbstractProvider {
   ): Promise<TransactionResponse> {
     throw new Error('Not implemented')
   }
+
   // Network
   getBlock(blockNumber: number): Promise<Block> {
     throw new Error('Not implemented')
   }
+
   getBlockWithTransactions(blockHeight: number): Promise<Block> {
     throw new Error('Not implemented')
   }
+
   getTransaction(transactionHash: string): Promise<TransactionResponse> {
     throw new Error('Not implemented')
   }
+
   getBlockNumber(): Promise<number> {
     throw new Error('Not implemented')
   }
+
   getNodes(getNodesOptions: GetNodesOptions): Promise<Node[]> {
     throw new Error('Not implemented')
   }
+
   getNode(address: string | Promise<string>, GetNodeOptions): Promise<Node> {
     throw new Error('Not implemented')
   }
+
   getApps(getAppOption: GetAppOptions): Promise<App[]> {
     throw new Error('Not implemented')
   }
-  getApp(address: string | Promise<string>, GetAppOptions): Promise<App> {
-    throw new Error('Not implemented')
+
+  async getApp(
+    address: string | Promise<string>,
+    options: GetAppOptions
+  ): Promise<App> {
+    const res = await this.perform({
+      route: V1RpcRoutes.QueryApp,
+      body: { address: await address },
+    })
+    const app = await res.json()
+
+    if (!('chains' in app)) {
+      console.log(app)
+      throw new Error('RPC Error')
+    }
+
+    const { chains, jailed, max_relays, public_key, staked_tokens, status } =
+      app
+
+    return {
+      address,
+      chains,
+      publicKey: public_key,
+      jailed,
+      maxRelays: BigInt(max_relays),
+      stakedTokens: BigInt(staked_tokens),
+      status,
+    }
   }
-  getAccount(address: string | Promise<string>): Promise<Account> {
-    throw new Error('Not implemented')
+
+  async getAccount(address: string | Promise<string>): Promise<Account> {
+    const res = await this.perform({
+      route: V1RpcRoutes.QueryAccount,
+      body: { address: await address },
+    })
+    const account = await res.json()
+
+    if (!('address' in account)) {
+      throw new Error('RPC Error')
+    }
+
+    const { coins, public_key } = account
+
+    return {
+      address,
+      balance: BigInt(coins[0].amount),
+      publicKey: public_key,
+    }
   }
+
   getAccountWithTransactions(
     address: string | Promise<string>
   ): Promise<AccountWithTransactions> {

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -1,0 +1,67 @@
+import {
+  Account,
+  AccountWithTransactions,
+  App,
+  Block,
+  GetAppOptions,
+  GetNodesOptions,
+  TransactionResponse,
+} from '@pokt-foundation/pocketjs-types'
+import { AbstractProvider } from './abstract-provider'
+
+export class JsonRpcProvider implements AbstractProvider {
+  getNetwork(): Promise<string> {
+    throw new Error('Not implemented')
+  }
+  getBalance(address: string | Promise<string>): Promise<bigint> {
+    throw new Error('Not implemented')
+  }
+  getTransactionCount(address: string | Promise<string>): Promise<number> {
+    throw new Error('Not implemented')
+  }
+  getType(
+    address: string | Promise<string>
+  ): Promise<'node' | 'app' | 'account'> {
+    throw new Error('Not implemented')
+  }
+
+  // Txs
+  sendTransaction(
+    signedTransaction: string | Promise<string>
+  ): Promise<TransactionResponse> {
+    throw new Error('Not implemented')
+  }
+  // Network
+  getBlock(blockNumber: number): Promise<Block> {
+    throw new Error('Not implemented')
+  }
+  getBlockWithTransactions(blockHeight: number): Promise<Block> {
+    throw new Error('Not implemented')
+  }
+  getTransaction(transactionHash: string): Promise<TransactionResponse> {
+    throw new Error('Not implemented')
+  }
+  getBlockNumber(): Promise<number> {
+    throw new Error('Not implemented')
+  }
+  getNodes(getNodesOptions: GetNodesOptions): Promise<Node[]> {
+    throw new Error('Not implemented')
+  }
+  getNode(address: string | Promise<string>, GetNodeOptions): Promise<Node> {
+    throw new Error('Not implemented')
+  }
+  getApps(getAppOption: GetAppOptions): Promise<App[]> {
+    throw new Error('Not implemented')
+  }
+  getApp(address: string | Promise<string>, GetAppOptions): Promise<App> {
+    throw new Error('Not implemented')
+  }
+  getAccount(address: string | Promise<string>): Promise<Account> {
+    throw new Error('Not implemented')
+  }
+  getAccountWithTransactions(
+    address: string | Promise<string>
+  ): Promise<AccountWithTransactions> {
+    throw new Error('Not implemented')
+  }
+}

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -88,10 +88,22 @@ export class JsonRpcProvider implements AbstractProvider {
   }
 
   // Txs
-  sendTransaction(
+  async sendTransaction(
+    signerAddress: string | Promise<string>,
     signedTransaction: string | Promise<string>
   ): Promise<TransactionResponse> {
-    throw new Error('Not implemented')
+    const res = await this.perform({
+      route: V1RpcRoutes.ClientRawTx,
+      body: { address: await signerAddress, txHex: await signedTransaction },
+    })
+
+    const transactionResponse = await res.json()
+
+    if (!('hash' in transactionResponse)) {
+      throw new Error('RPC Error')
+    }
+
+    return transactionResponse
   }
 
   // Network

--- a/packages/provider/src/routes.ts
+++ b/packages/provider/src/routes.ts
@@ -1,0 +1,38 @@
+/**
+ * Enum listing versions supported by this SDK
+ */
+enum Versions {
+  V1 = '/v1',
+}
+
+/**
+ * Enum indicating all the routes in the V1 RPC Interface
+ */
+export enum V1RpcRoutes {
+  ClientChallenge = Versions.V1 + '/client/challenge',
+  ClientDispatch = Versions.V1 + '/client/dispatch',
+  ClientRawTx = Versions.V1 + '/client/rawtx',
+  ClientRelay = Versions.V1 + '/client/relay',
+  QueryAccount = Versions.V1 + '/query/account',
+  QueryAccountTxs = Versions.V1 + '/query/accounttxs',
+  QueryAllParams = Versions.V1 + '/query/allparams',
+  QueryApp = Versions.V1 + '/query/app',
+  QueryAppParams = Versions.V1 + '/query/appparams',
+  QueryApps = Versions.V1 + '/query/apps',
+  QueryBalance = Versions.V1 + '/query/balance',
+  QueryBlock = Versions.V1 + '/query/block',
+  QueryBlockTxs = Versions.V1 + '/query/blocktxs',
+  QueryHeight = Versions.V1 + '/query/height',
+  QueryNode = Versions.V1 + '/query/node',
+  QueryNodeClaim = Versions.V1 + '/query/nodeclaim',
+  QueryNodeClaims = Versions.V1 + '/query/nodeclaims',
+  QueryNodeParams = Versions.V1 + '/query/nodeparams',
+  QueryNodeReceipt = Versions.V1 + '/query/nodereceipt',
+  QueryNodeReceipts = Versions.V1 + '/query/nodereceipts',
+  QueryNodes = Versions.V1 + '/query/nodes',
+  QueryPocketParams = Versions.V1 + '/query/pocketparams',
+  QuerySupply = Versions.V1 + '/query/supply',
+  QuerySupportedChains = Versions.V1 + '/query/supportedchains',
+  QueryTX = Versions.V1 + '/query/tx',
+  QueryUpgrade = Versions.V1 + '/query/upgrade',
+}

--- a/packages/provider/tsconfig.json
+++ b/packages/provider/tsconfig.json
@@ -7,5 +7,6 @@
     "composite": true
   },
   "references": [{ "path": "../types" }],
+  "include": ["src"],
   "exclude": ["node_modules"]
 }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "description": "PocketJS types",
   "type": "module",
-  "source": "src/index.d.ts",
+  "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
     "default": "./dist/index.js"

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -19,6 +19,10 @@ export interface GetAppOptions {}
 
 export interface App {}
 
-export interface Account {}
+export interface Account {
+  address: string
+  balance: bigint
+  publicKey: null | string
+}
 
 export type AccountWithTransactions = Account

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -17,7 +17,21 @@ export interface GetNodesOptions {}
 
 export interface GetAppOptions {}
 
-export interface App {}
+export enum StakingStatus {
+    Unstaked = 0,
+    Unstaking = 1,
+    Staked = 2
+}
+
+export interface App {
+  address: string
+  chains: string[],
+  jailed: boolean,
+  maxRelays: bigint,
+  publicKey: string,
+  stakedTokens: bigint,
+  status: StakingStatus
+}
 
 export interface Account {
   address: string

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -50,6 +50,10 @@ export interface Account {
   publicKey: null | string
 }
 
-export type AccountWithTransactions = Account
+export type AccountWithTransactions = Account & {
+  totalCount: number
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  transactions: any[]
+}
 
 export {}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -18,19 +18,30 @@ export interface GetNodesOptions {}
 export interface GetAppOptions {}
 
 export enum StakingStatus {
-    Unstaked = 0,
-    Unstaking = 1,
-    Staked = 2
+  Unstaked = 0,
+  Unstaking = 1,
+  Staked = 2,
 }
 
 export interface App {
   address: string
-  chains: string[],
-  jailed: boolean,
-  maxRelays: bigint,
-  publicKey: string,
-  stakedTokens: bigint,
+  chains: string[]
+  jailed: boolean
+  maxRelays: bigint
+  publicKey: string
+  stakedTokens: bigint
   status: StakingStatus
+}
+
+export interface Node {
+  address: string
+  chains: string[]
+  jailed: boolean
+  publicKey: string
+  serviceUrl: string
+  stakedTokens: bigint
+  status: StakingStatus
+  unstakingTime: string
 }
 
 export interface Account {
@@ -40,3 +51,5 @@ export interface Account {
 }
 
 export type AccountWithTransactions = Account
+
+export {}

--- a/packages/types/tsconfig.json
+++ b/packages/types/tsconfig.json
@@ -6,7 +6,8 @@
     "baseUrl": ".",
     "allowJs": true,
     "composite": true,
-    "declaration": true
+    "declaration": true,
+    "declarationDir": "dist"
   },
   "references": [],
   "exclude": ["node_modules", "dist", "jest.config.js"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,11 +66,14 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
       eslint: 7.32.0
+      isomorphic-unfetch: ^3.1.0
       jest: ^27.4.7
       microbundle: ^0.14.2
       prettier: ^2.5.1
       ts-jest: ^27.1.3
       typescript: ^4.5.5
+    dependencies:
+      isomorphic-unfetch: 3.1.0
     devDependencies:
       '@pokt-foundation/pocketjs-types': link:../types
       '@types/jest': 27.4.0
@@ -3792,6 +3795,15 @@ packages:
     resolution: {integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=}
     dev: true
 
+  /isomorphic-unfetch/3.1.0:
+    resolution: {integrity: sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==}
+    dependencies:
+      node-fetch: 2.6.7
+      unfetch: 4.2.0
+    transitivePeerDependencies:
+      - encoding
+    dev: false
+
   /istanbul-lib-coverage/3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
     engines: {node: '>=8'}
@@ -4667,6 +4679,18 @@ packages:
   /natural-compare/1.4.0:
     resolution: {integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=}
     dev: true
+
+  /node-fetch/2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+    dependencies:
+      whatwg-url: 5.0.0
+    dev: false
 
   /node-int64/0.4.0:
     resolution: {integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=}
@@ -5934,6 +5958,10 @@ packages:
       universalify: 0.1.2
     dev: true
 
+  /tr46/0.0.3:
+    resolution: {integrity: sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=}
+    dev: false
+
   /tr46/2.1.0:
     resolution: {integrity: sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==}
     engines: {node: '>=8'}
@@ -6178,6 +6206,10 @@ packages:
       which-boxed-primitive: 1.0.2
     dev: true
 
+  /unfetch/4.2.0:
+    resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}
+    dev: false
+
   /unicode-canonical-property-names-ecmascript/2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
     engines: {node: '>=4'}
@@ -6265,6 +6297,10 @@ packages:
       makeerror: 1.0.12
     dev: true
 
+  /webidl-conversions/3.0.1:
+    resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}
+    dev: false
+
   /webidl-conversions/5.0.0:
     resolution: {integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==}
     engines: {node: '>=8'}
@@ -6284,6 +6320,13 @@ packages:
   /whatwg-mimetype/2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
     dev: true
+
+  /whatwg-url/5.0.0:
+    resolution: {integrity: sha1-lmRU6HZUYuN2RNNib2dCzotwll0=}
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+    dev: false
 
   /whatwg-url/8.7.0:
     resolution: {integrity: sha512-gAojqb/m9Q8a5IV96E3fHJM70AzCkgt4uXYX2O7EmuyOnLrViCQlsEBmF9UQIu3/aeAIp2U17rtbpZWNntQqdg==}


### PR DESCRIPTION
Adds a barebones JSON-RPC provider to use with direct connection to a pocket node. It's exactly the same provider available in PocketJS—Just without all the extra bits actually working (yet).