### PR TITLE
TSConfig: Declaration/Source fixes

### DIFF
--- a/packages/pocket/tsconfig.json
+++ b/packages/pocket/tsconfig.json
@@ -5,12 +5,15 @@
   "compilerOptions": {
     "baseUrl": ".",
     "allowJs": true,
-    "composite": true
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "dist"
   },
   "references": [
     { "path": "../utils" },
     { "path": "../signer" },
     { "path": "../provider" }
   ],
+  "include": ["src"],
   "exclude": ["node_modules", "dist", "jest.config.js"]
 }

--- a/packages/relayer/tsconfig.json
+++ b/packages/relayer/tsconfig.json
@@ -5,12 +5,15 @@
   "compilerOptions": {
     "baseUrl": ".",
     "allowJs": true,
-    "composite": true
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "dist"
   },
   "references": [
     { "path": "../utils" },
     { "path": "../signer" },
     { "path": "../provider" }
   ],
+  "include": ["src"],
   "exclude": ["node_modules", "dist", "jest.config.js"]
 }

--- a/packages/signer/tsconfig.json
+++ b/packages/signer/tsconfig.json
@@ -4,7 +4,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "baseUrl": ".",
-    "composite": true
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "dist"
   },
   "references": [{ "path": "../provider" }, { "path": "../utils" }],
   "include": ["src"],

--- a/packages/transaction-builder/tsconfig.json
+++ b/packages/transaction-builder/tsconfig.json
@@ -5,12 +5,15 @@
   "compilerOptions": {
     "baseUrl": ".",
     "allowJs": true,
-    "composite": true
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "dist"
   },
   "references": [
     { "path": "../utils" },
     { "path": "../signer" },
     { "path": "../provider" }
   ],
+  "include": ["src"],
   "exclude": ["node_modules", "dist", "jest.config.js"]
 }

--- a/packages/transactions/tsconfig.json
+++ b/packages/transactions/tsconfig.json
@@ -5,7 +5,9 @@
   "compilerOptions": {
     "baseUrl": ".",
     "allowJs": true,
-    "composite": true
+    "composite": true,
+    "declaration": true,
+    "declarationDir": "dist"
   },
   "references": [
     { "path": "../utils" },


### PR DESCRIPTION
On these packages, due to a bug on microbundle declarations were not being emitted on the correct folder. The workaround is just to put an arbitrary folder in the tsconfig. Also fixes a misconfig for pointing to source files by adding the whole `src` folder.