### PR TITLE
Relayer: Add barebones implementation

### DIFF
--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -329,9 +329,11 @@ export class JsonRpcProvider implements AbstractProvider {
 
     return {
       blockHeight,
-      header: formattedHeader,
-      nodes: formattedNodes,
-      key,
+      session: {
+        header: formattedHeader,
+        nodes: formattedNodes,
+        key,
+      },
     }
   }
 }

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -283,14 +283,20 @@ export class JsonRpcProvider implements AbstractProvider {
   }
 
   async dispatch(request: DispatchRequest): Promise<DispatchResponse> {
+    console.log(request.sessionHeader)
     const dispatchRes = await this.perform({
       route: V1RpcRoutes.ClientDispatch,
-      body: { session_header: request.sessionHeader },
+      body: {
+        app_public_key: request.sessionHeader.applicationPubKey,
+        chain: request.sessionHeader.chain,
+        session_height: request.sessionHeader.sessionBlockHeight,
+      },
     })
 
     const dispatch = await dispatchRes.json()
 
     if (!('session' in dispatch)) {
+      console.log(dispatch, 'error')
       throw new Error('RPC Error')
     }
 

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -46,6 +46,7 @@ export class JsonRpcProvider implements AbstractProvider {
           Math.floor(Math.random() * 100) % this.dispatchers.length
         ]
       : this.rpcUrl
+
     return fetch(`${finalRpcUrl}${route}`, {
       method: 'POST',
       headers: {
@@ -369,7 +370,7 @@ export class JsonRpcProvider implements AbstractProvider {
     const relayAttempt = await this.perform({
       route: V1RpcRoutes.ClientRelay,
       body: request,
-      rpcUrl
+      rpcUrl,
     })
 
     const relayResponse = await relayAttempt.json()

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -24,7 +24,7 @@ export class JsonRpcProvider implements AbstractProvider {
     dispatchers = [],
   }: {
     rpcUrl: string
-    dispatchers: string[]
+    dispatchers?: string[]
   }) {
     this.rpcUrl = rpcUrl
     this.dispatchers = dispatchers ?? []

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -47,13 +47,20 @@ export class JsonRpcProvider implements AbstractProvider {
         ]
       : this.rpcUrl
 
-    return fetch(`${finalRpcUrl}${route}`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(body),
-    })
+    try {
+      const rpcResponse = fetch(`${finalRpcUrl}${route}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      })
+      return rpcResponse
+    } catch (err) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        return err
+    }
   }
 
   async getBalance(address: string | Promise<string>): Promise<bigint> {
@@ -366,7 +373,7 @@ export class JsonRpcProvider implements AbstractProvider {
     }
   }
 
-  async relay(request, rpcUrl: string): Promise<any> {
+  async relay(request, rpcUrl: string): Promise<unknown> {
     const relayAttempt = await this.perform({
       route: V1RpcRoutes.ClientRelay,
       body: request,

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@pokt-foundation/pocketjs-provider": "^0.0.0",
     "@pokt-foundation/pocketjs-signer": "^0.0.0",
-    "@pokt-foundation/pocketjs-types": "^0.0.0"
+    "@pokt-foundation/pocketjs-types": "^0.0.0",
+    "js-sha256": "^0.9.0",
+    "js-sha3": "^0.8.0"
   }
 }

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -29,5 +29,10 @@
     "prettier": "^2.5.1",
     "prettier-eslint": "^13.0.0",
     "ts-jest": "^27.1.3"
+  },
+  "dependencies": {
+    "@pokt-foundation/pocketjs-provider": "^0.0.0",
+    "@pokt-foundation/pocketjs-signer": "^0.0.0",
+    "@pokt-foundation/pocketjs-types": "^0.0.0"
   }
 }

--- a/packages/relayer/src/abstract-relayer.ts
+++ b/packages/relayer/src/abstract-relayer.ts
@@ -1,14 +1,53 @@
+import { AbstractSigner, KeyManager } from '@pokt-foundation/pocketjs-signer'
+import { AbstractProvider } from '@pokt-foundation/pocketjs-provider'
 import {
+  HTTPMethod,
   Node,
   PocketAAT,
+  RelayHeaders,
+  RelayResponse,
   Session,
   SessionHeader,
 } from '@pokt-foundation/pocketjs-types'
 
 export abstract class AbstractRelayer {
-  abstract getNewSession(
-    pocketAAT: PocketAAT,
-    chain: string,
+  readonly keyManager: KeyManager | AbstractSigner
+  readonly provider: AbstractProvider
+  readonly dispatchers: string[]
+
+  constructor({ keyManager, provider, dispatchers }) {
+    this.keyManager = keyManager
+    this.provider = provider
+    this.dispatchers = dispatchers
+  }
+
+  abstract getNewSession({
+    pocketAAT,
+    chain,
+    options,
+  }: {
+    pocketAAT: PocketAAT
+    chain: string
     options?: { retryAttempts: number; rejectSelfSignedCertificates: boolean }
-  ): Session
+  }): Session
+
+  abstract relay({
+    data,
+    blockchain,
+    pocketAAT,
+    headers,
+    method,
+    session,
+    node,
+    path,
+  }: {
+    data: string
+    blockchain: string
+    pocketAAT: PocketAAT
+    headers: RelayHeaders
+    method: HTTPMethod
+    session: Session
+    node: Node
+    path: string
+  }): Promise<RelayResponse>
 }

--- a/packages/relayer/src/abstract-relayer.ts
+++ b/packages/relayer/src/abstract-relayer.ts
@@ -5,9 +5,7 @@ import {
   Node,
   PocketAAT,
   RelayHeaders,
-  RelayResponse,
   Session,
-  SessionHeader,
 } from '@pokt-foundation/pocketjs-types'
 
 export abstract class AbstractRelayer {

--- a/packages/relayer/src/abstract-relayer.ts
+++ b/packages/relayer/src/abstract-relayer.ts
@@ -1,0 +1,14 @@
+import {
+  Node,
+  PocketAAT,
+  Session,
+  SessionHeader,
+} from '@pokt-foundation/pocketjs-types'
+
+export abstract class AbstractRelayer {
+  abstract getNewSession(
+    pocketAAT: PocketAAT,
+    chain: string,
+    options?: { retryAttempts: number; rejectSelfSignedCertificates: boolean }
+  ): Session
+}

--- a/packages/relayer/src/abstract-relayer.ts
+++ b/packages/relayer/src/abstract-relayer.ts
@@ -49,5 +49,5 @@ export abstract class AbstractRelayer {
     session: Session
     node: Node
     path: string
-  }): Promise<RelayResponse>
+  }): void
 }

--- a/packages/relayer/src/abstract-relayer.ts
+++ b/packages/relayer/src/abstract-relayer.ts
@@ -29,7 +29,7 @@ export abstract class AbstractRelayer {
     pocketAAT: PocketAAT
     chain: string
     options?: { retryAttempts: number; rejectSelfSignedCertificates: boolean }
-  }): Session
+  }): Promise<Session>
 
   abstract relay({
     data,

--- a/packages/relayer/src/errors.ts
+++ b/packages/relayer/src/errors.ts
@@ -1,0 +1,56 @@
+export class PocketCoreError extends Error {
+  code: number
+
+  constructor(code: number, ...params: any[]) {
+    super(...params)
+    this.code = code
+  }
+}
+
+export class EmptyPayloadError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, ...params)
+    this.message = message
+    this.name = 'EmptyPayloadError'
+  }
+}
+
+export class RequestHashError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, ...params)
+    this.message = message
+    this.name = 'RequestHashError'
+  }
+}
+
+export class UnsupportedBlockchainNodeError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, ...params)
+    this.message = message
+    this.name = 'UnsupportedBlockchainNodeError'
+  }
+}
+
+export class InvalidBlockHeightError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, ...params)
+    this.message = message
+    this.name = 'InvalidBlockHeightError'
+  }
+}
+
+export class AppNotFoundError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, ...params)
+    this.message = message
+    this.name = 'AppNotFoundError'
+  }
+}
+
+export class SealedEvidenceError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, ...params)
+    this.message = message
+    this.name = 'AppNotFoundError'
+  }
+}

--- a/packages/relayer/src/errors.ts
+++ b/packages/relayer/src/errors.ts
@@ -1,56 +1,136 @@
+export enum PocketCoreErrorCodes {
+  AppNotFoundError = 45,
+  DuplicateProofError = 37,
+  EmptyPayloadDataError = 25,
+  EvidenceSealedError = 90,
+  InvalidBlockHeightError = 60,
+  OverServiceError = 71,
+  RequestHashError = 74,
+  UnsupportedBlockchainError = 76,
+}
+
 export class PocketCoreError extends Error {
   code: number
+  message: string
 
-  constructor(code: number, ...params: any[]) {
+  constructor(code: number, message: string, ...params: any[]) {
     super(...params)
     this.code = code
+    this.message = message
   }
 }
 
-export class EmptyPayloadError extends PocketCoreError {
+export class EmptyPayloadDataError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
-    super(code, ...params)
-    this.message = message
+    super(code, message, ...params)
     this.name = 'EmptyPayloadError'
   }
 }
 
 export class RequestHashError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
-    super(code, ...params)
-    this.message = message
+    super(code, message, ...params)
     this.name = 'RequestHashError'
   }
 }
 
-export class UnsupportedBlockchainNodeError extends PocketCoreError {
+export class UnsupportedBlockchainError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
-    super(code, ...params)
-    this.message = message
-    this.name = 'UnsupportedBlockchainNodeError'
+    super(code, message, ...params)
+    this.name = 'UnsupportedBlockchainError'
   }
 }
 
 export class InvalidBlockHeightError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
-    super(code, ...params)
-    this.message = message
+    super(code, message, ...params)
     this.name = 'InvalidBlockHeightError'
   }
 }
 
 export class AppNotFoundError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
-    super(code, ...params)
-    this.message = message
+    super(code, message, ...params)
     this.name = 'AppNotFoundError'
   }
 }
 
-export class SealedEvidenceError extends PocketCoreError {
+export class EvidenceSealedError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
-    super(code, ...params)
-    this.message = message
-    this.name = 'AppNotFoundError'
+    super(code, message, ...params)
+    this.name = 'EvidenceSealedError'
+  }
+}
+
+export class DuplicateProofError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, message, ...params)
+    this.name = 'DuplicateProofError'
+  }
+}
+
+export class OverServiceError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, message, ...params)
+    this.name = 'OverServiceError'
+  }
+}
+
+export function validateRelayResponse(relayResponse: any) {
+  if ('response' in relayResponse && 'signature' in relayResponse) {
+    return relayResponse.response
+  }
+
+  // probably an unhandled error
+  if (!('response' in relayResponse) && !('error' in relayResponse)) {
+    return relayResponse
+  }
+
+  switch (relayResponse.error.code) {
+    case PocketCoreErrorCodes.AppNotFoundError:
+      throw new AppNotFoundError(
+        PocketCoreErrorCodes.AppNotFoundError,
+        relayResponse.error.message ?? ''
+      )
+    case PocketCoreErrorCodes.DuplicateProofError:
+      throw new DuplicateProofError(
+        PocketCoreErrorCodes.DuplicateProofError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.EmptyPayloadDataError:
+      throw new EmptyPayloadDataError(
+        PocketCoreErrorCodes.EmptyPayloadDataError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.EvidenceSealedError:
+      throw new EvidenceSealedError(
+        PocketCoreErrorCodes.EvidenceSealedError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.InvalidBlockHeightError:
+      throw new InvalidBlockHeightError(
+        PocketCoreErrorCodes.InvalidBlockHeightError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.OverServiceError:
+      throw new OverServiceError(
+        PocketCoreErrorCodes.OverServiceError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.RequestHashError:
+      throw new RequestHashError(
+        PocketCoreErrorCodes.RequestHashError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.UnsupportedBlockchainError:
+      throw new UnsupportedBlockchainError(
+        PocketCoreErrorCodes.UnsupportedBlockchainError,
+        relayResponse.error.message
+      )
+    default:
+      throw new PocketCoreError(
+        relayResponse.error.code,
+        relayResponse.error.message ?? ''
+      )
   }
 }

--- a/packages/relayer/src/index.ts
+++ b/packages/relayer/src/index.ts
@@ -1,5 +1,2 @@
-export class Relayer {
-  public static gm() {
-    console.log('gm')
-  }
-}
+export * from './abstract-relayer'
+export * from './relayer'

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -1,5 +1,54 @@
-export class Relayer {
-  static gm() {
-    console.log('gm')
+import { AbstractProvider } from '@pokt-foundation/pocketjs-provider'
+import { AbstractSigner, KeyManager } from '@pokt-foundation/pocketjs-signer'
+import {
+  HTTPMethod,
+  Node,
+  PocketAAT,
+  RelayHeaders,
+  RelayResponse,
+  Session,
+  SessionHeader,
+} from '@pokt-foundation/pocketjs-types'
+import { AbstractRelayer } from './abstract-relayer'
+
+export class Relayer implements AbstractRelayer {
+  readonly keyManager: KeyManager | AbstractSigner
+  readonly provider: AbstractProvider
+  readonly dispatchers: string[]
+
+  constructor({ keyManager, provider, dispatchers }) {
+    this.keyManager = keyManager
+    this.provider = provider
+    this.dispatchers = dispatchers
   }
+
+  getNewSession({
+    pocketAAT,
+    chain,
+    options,
+  }: {
+    pocketAAT: PocketAAT
+    chain: string
+    options?: { retryAttempts: number; rejectSelfSignedCertificates: boolean }
+  }): Session {}
+
+  relay({
+    data,
+    blockchain,
+    pocketAAT,
+    headers,
+    method,
+    session,
+    node,
+    path,
+  }: {
+    data: string
+    blockchain: string
+    pocketAAT: PocketAAT
+    headers: RelayHeaders
+    method: HTTPMethod
+    session: Session
+    node: Node
+    path: string
+  }): Promise<RelayResponse> {}
 }

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -172,7 +172,7 @@ export class Relayer implements AbstractRelayer {
     // Hash proofJSONStr
     const hash = sha3_256.create()
     hash.update(proofJSONStr)
-    return Buffer.from(hash.hex(), 'hex')
+    return hash.hex()
   }
 
   hashAAT(aat: PocketAAT): string {

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -14,6 +14,7 @@ import {
   SessionHeader,
 } from '@pokt-foundation/pocketjs-types'
 import { AbstractRelayer } from './abstract-relayer'
+import { validateRelayResponse } from './errors'
 
 export class Relayer implements AbstractRelayer {
   readonly keyManager: KeyManager | AbstractSigner
@@ -29,6 +30,7 @@ export class Relayer implements AbstractRelayer {
   async getNewSession({
     applicationPubKey,
     chain,
+    sessionBlockHeight = 0,
     options = {
       retryAttempts: 3,
       rejectSelfSignedCertificates: false,
@@ -37,6 +39,7 @@ export class Relayer implements AbstractRelayer {
   }: {
     applicationPubKey?: string
     chain: string
+    sessionBlockHeight?: number
     options?: {
       retryAttempts?: number
       rejectSelfSignedCertificates?: boolean
@@ -47,7 +50,7 @@ export class Relayer implements AbstractRelayer {
       sessionHeader: {
         applicationPubKey: applicationPubKey ?? this.keyManager.getPublicKey(),
         chain,
-        sessionBlockHeight: 0,
+        sessionBlockHeight: sessionBlockHeight ?? 0,
       },
     })
 
@@ -149,7 +152,9 @@ export class Relayer implements AbstractRelayer {
       serviceNode.serviceUrl.toString()
     )
 
-    return relay
+    const relayResponse = validateRelayResponse(relay)
+
+    return relayResponse
   }
 
   async relay({

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -5,7 +5,10 @@ import {
   Node,
   PocketAAT,
   RelayHeaders,
+  RelayMeta,
+  RelayPayload,
   RelayResponse,
+  RequestHash,
   Session,
   SessionHeader,
 } from '@pokt-foundation/pocketjs-types'
@@ -28,17 +31,19 @@ export class Relayer implements AbstractRelayer {
   }: {
     chain: string
     options?: { retryAttempts: number; rejectSelfSignedCertificates: boolean }
-    }): Promise<Session> {
-      const dispatchResponse = await this.provider.dispatch({ sessionHeader: {
+  }): Promise<Session> {
+    const dispatchResponse = await this.provider.dispatch({
+      sessionHeader: {
         applicationPubKey: this.keyManager.getPublicKey(),
         chain,
         sessionBlockHeight: 0,
-      } })
+      },
+    })
 
-      return dispatchResponse.session as Session
-    }
+    return dispatchResponse.session as Session
+  }
 
-  relay({
+  async relay({
     data,
     blockchain,
     pocketAAT,
@@ -56,7 +61,136 @@ export class Relayer implements AbstractRelayer {
     session: Session
     node: Node
     path: string
-    }) {
-      console.log('nyom relay')
+  }) {
+    if (!this.keyManager) {
+      throw new Error('You need a signer to send a relay')
     }
+    const serviceNode = node ?? this.getRandomSessionNode(session)
+
+    if (!serviceNode) {
+      throw new Error(`Couldn't find a service node.`)
+    }
+
+    if (!this.isNodeInSession(session, serviceNode)) {
+      throw new Error(`Node is not in the current session`)
+    }
+
+    const relayPayload = {
+      data,
+      headers,
+      method,
+      path,
+    } as RelayPayload
+
+    const relayMeta = {
+      block_height: session.header.sessionBlockHeight.toString(),
+    }
+
+    const requestHash = {
+      payload: relayPayload,
+      meta: relayMeta,
+    }
+
+    const entropy = BigInt(Math.random() * 999999999999)
+
+    const proofBytes = this.generateProofBytes({
+      entropy,
+      sessionBlockHeight: session.header.sessionBlockHeight.toString(),
+      servicerPublicKey: serviceNode.publicKey,
+      blockchain,
+      pocketAAT,
+      requestHash,
+    })
+
+    const signedProofBytes = await this.keyManager.sign(proofBytes)
+
+    const relayProof = {
+      entropy,
+      session_block_height: session.header.sessionBlockHeight.toString(),
+      servicer_pub_key: serviceNode.publicKey,
+      blockchain,
+      aat: {
+        version: pocketAAT.version,
+        app_pub_key: pocketAAT.applicationPublicKey,
+        client_pub_key: pocketAAT.clientPublicKey,
+        signature: pocketAAT.applicationSignature,
+      },
+      signature: signedProofBytes,
+      requestHash: {
+        payload: relayPayload,
+        meta: relayMeta,
+      },
+    }
+
+    const relayRequest = {
+      payload: relayPayload,
+      meta: relayMeta,
+      proof: relayProof,
+    }
+
+    const relay = await this.provider.relay(relayRequest)
+
+    return relay
+  }
+
+  getRandomSessionNode(session: Session): Node {
+    const nodesInSession = session.nodes.length
+    const rng = (Math.random() * 100) % nodesInSession
+
+    return session.nodes[rng]
+  }
+
+  isNodeInSession(session: Session, node: Node): boolean {
+    return Boolean(session.nodes.find((n) => n.publicKey === node.publicKey))
+  }
+
+  generateProofBytes({
+    entropy,
+    sessionBlockHeight,
+    servicerPublicKey,
+    blockchain,
+    pocketAAT,
+    requestHash,
+  }: {
+    entropy: bigint
+    sessionBlockHeight: string
+    servicerPublicKey: string
+    blockchain: string
+    pocketAAT: PocketAAT
+    requestHash: any
+  }): string {
+    const proofJSON = {
+      entropy: Number(entropy.toString()),
+      session_block_height: Number(sessionBlockHeight.toString()),
+      servicer_pub_key: servicerPublicKey,
+      blockchain: blockchain,
+      signature: '',
+      token: this.hashAAT(pocketAAT),
+      request_hash: this.hashRequest(requestHash),
+    }
+    const proofJSONStr = JSON.stringify(proofJSON)
+    // Hash proofJSONStr
+    const hash = sha3_256.create()
+    hash.update(proofJSONStr)
+    return Buffer.from(hash.hex(), 'hex')
+  }
+
+  hashAAT(aat: PocketAAT): string {
+    const token = {
+      version: aat.version,
+      app_pub_key: aat.applicationPublicKey,
+      client_pub_key: aat.clientPublicKey,
+      signature: '',
+    }
+    // Generate sha3 hash of the aat payload object
+    const hash = sha3_256.create()
+    hash.update(JSON.stringify(token))
+    return hash.hex()
+  }
+
+  hashRequest(requestHash): string {
+    const hash = sha3_256.create()
+    hash.update(requestHash)
+    return hash.hex()
+  }
 }

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -32,7 +32,7 @@ export class Relayer implements AbstractRelayer {
       const dispatchResponse = await this.provider.dispatch({ sessionHeader: {
         applicationPubKey: this.keyManager.getPublicKey(),
         chain,
-        sessionBlockHeight: BigInt(0),
+        sessionBlockHeight: 0,
       } })
 
       return dispatchResponse.session as Session
@@ -56,5 +56,7 @@ export class Relayer implements AbstractRelayer {
     session: Session
     node: Node
     path: string
-  }): Promise<RelayResponse> {}
+    }) {
+      console.log('nyom relay')
+    }
 }

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -1,0 +1,5 @@
+export class Relayer {
+  static gm() {
+    console.log('gm')
+  }
+}

--- a/packages/relayer/tsconfig.json
+++ b/packages/relayer/tsconfig.json
@@ -12,7 +12,8 @@
   "references": [
     { "path": "../utils" },
     { "path": "../signer" },
-    { "path": "../provider" }
+    { "path": "../provider" },
+    { "path": "../types" }
   ],
   "include": ["src"],
   "exclude": ["node_modules", "dist", "jest.config.js"]

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -35,6 +35,7 @@
     "@pokt-foundation/pocketjs-provider": "^0.0.0",
     "@pokt-foundation/pocketjs-types": "^0.0.0",
     "@pokt-foundation/pocketjs-utils": "^0.0.0",
+    "hex-lite": "^1.5.0",
     "libsodium-wrappers": "^0.7.9"
   }
 }

--- a/packages/signer/src/abstract-signer.ts
+++ b/packages/signer/src/abstract-signer.ts
@@ -22,6 +22,6 @@ export abstract class AbstractSigner {
   abstract sendTransaction(
     signedTransaction: string | Promise<string>
   ): Promise<TransactionResponse>
-  abstract signMessage(message: string): Promise<string>
+  abstract sign(payload: string): Promise<string>
   abstract signTransaction(transaction: TransactionRequest): Promise<string>
 }

--- a/packages/signer/src/key-manager.ts
+++ b/packages/signer/src/key-manager.ts
@@ -33,7 +33,6 @@ export class KeyManager {
 
   async sign(payload: string): Promise<string> {
     await Sodium.ready
-    console.log(Sodium.to_hex, toUint8Array(this.getPrivateKey()))
     return fromUint8Array(Sodium.crypto_sign_detached(toUint8Array(payload), toUint8Array(this.getPrivateKey())))
   }
 

--- a/packages/signer/src/key-manager.ts
+++ b/packages/signer/src/key-manager.ts
@@ -1,5 +1,5 @@
-import { utils } from '@noble/ed25519'
 import Sodium from 'libsodium-wrappers'
+import { toUint8Array, fromUint8Array } from 'hex-lite'
 import {
   getAddressFromPublicKey,
   publicKeyFromPrivate,
@@ -31,13 +31,18 @@ export class KeyManager {
     this.address = address
   }
 
+  async sign(payload: string): Promise<string> {
+    await Sodium.ready
+    console.log(Sodium.to_hex, toUint8Array(this.getPrivateKey()))
+    return fromUint8Array(Sodium.crypto_sign_detached(toUint8Array(payload), toUint8Array(this.getPrivateKey())))
+  }
+
   static async createRandom(): Promise<KeyManager> {
     await Sodium.ready
     const keypair = Sodium.crypto_sign_keypair()
-    const privateKey = utils.bytesToHex(keypair.privateKey)
-    const publicKey = utils.bytesToHex(keypair.publicKey)
+    const privateKey = fromUint8Array(keypair.privateKey)
+    const publicKey = fromUint8Array(keypair.publicKey)
     const addr = await getAddressFromPublicKey(publicKey)
-    console.log('CREATE_RANDOM', privateKey, publicKey, addr)
 
     return new KeyManager({ privateKey, publicKey, address: addr })
   }
@@ -46,7 +51,6 @@ export class KeyManager {
     await Sodium.ready
     const publicKey = publicKeyFromPrivate(privateKey)
     const addr = await getAddressFromPublicKey(publicKey)
-    console.log('FROM_PRIVATE_KEY', privateKey, publicKey, addr)
 
     return new KeyManager({ privateKey, publicKey, address: addr })
   }

--- a/packages/signer/src/wallet.ts
+++ b/packages/signer/src/wallet.ts
@@ -77,7 +77,6 @@ export class Wallet implements AbstractSigner {
 
   async sign(payload: string): Promise<string> {
     await Sodium.ready
-    console.log(Sodium.to_hex, toUint8Array(this.keyManager.getPrivateKey()))
     return fromUint8Array(
       Sodium.crypto_sign_detached(
         toUint8Array(payload),

--- a/packages/signer/src/wallet.ts
+++ b/packages/signer/src/wallet.ts
@@ -1,4 +1,5 @@
 import Sodium from 'libsodium-wrappers'
+import { toUint8Array, fromUint8Array } from 'hex-lite'
 import { AbstractProvider } from '@pokt-foundation/pocketjs-provider'
 import { TransactionResponse } from '@pokt-foundation/pocketjs-types'
 import { AbstractSigner, TransactionRequest } from './abstract-signer'
@@ -74,10 +75,15 @@ export class Wallet implements AbstractSigner {
     )
   }
 
-  async signMessage(message: string): Promise<string> {
+  async sign(payload: string): Promise<string> {
     await Sodium.ready
-
-    return Sodium.crypto_sign_detached(message, this.keyManager.getPrivateKey())
+    console.log(Sodium.to_hex, toUint8Array(this.keyManager.getPrivateKey()))
+    return fromUint8Array(
+      Sodium.crypto_sign_detached(
+        toUint8Array(payload),
+        toUint8Array(this.keyManager.getPrivateKey())
+      )
+    )
   }
 
   async signTransaction(transaction: TransactionRequest): Promise<string> {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -59,7 +59,7 @@ export type AccountWithTransactions = Account & {
 export interface SessionHeader {
   readonly applicationPubKey: string
   readonly chain: string
-  readonly sessionBlockHeight: bigint
+  readonly sessionBlockHeight: string | number
 }
 
 export type RelayHeaders = Record<string, string>

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -62,6 +62,8 @@ export interface SessionHeader {
   readonly sessionBlockHeight: bigint
 }
 
+export type RelayHeaders = Record<string, string>
+
 export interface PocketAAT {
   readonly version: string
   readonly clientPublicKey: string
@@ -73,6 +75,47 @@ export interface Session {
   readonly sessionHeader: SessionHeader
   readonly sessionKey: string
   readonly sessionNodes: Node[]
+}
+
+export enum HTTPMethod {
+  POST = 'POST',
+  GET = 'GET',
+  DELETE = 'DELETE',
+  NA = '',
+}
+
+export interface RelayProof {
+  readonly entropy: BigInt
+  readonly sessionBlockHeight: BigInt
+  readonly servicerPubKey: string
+  readonly blockchain: string
+  readonly token: PocketAAT
+  readonly signature: string
+  readonly requestHash: string
+}
+
+export interface RelayPayload {
+  readonly data: string
+  readonly method: string
+  readonly path: string
+  readonly headers?: RelayHeaders | null
+}
+
+export interface RelayMeta {
+  readonly blockHeight: bigint
+}
+
+export interface RelayRequest {
+  readonly payload: RelayPayload
+  readonly meta: RelayMeta
+  readonly proof: RelayProof
+}
+
+export interface RelayResponse {
+  readonly signature: string
+  readonly payload: string
+  readonly proof: RelayProof
+  readonly relayRequest: RelayRequest
 }
 
 export {}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -84,6 +84,18 @@ export enum HTTPMethod {
   NA = '',
 }
 
+export interface DispatchRequest {
+  readonly sessionHeader: SessionHeader
+}
+
+export interface DispatchResponse {
+  readonly blockHeight: BigInt
+  readonly header: SessionHeader
+  readonly key: string
+  readonly nodes: Node[]
+
+}
+
 export interface RelayProof {
   readonly entropy: BigInt
   readonly sessionBlockHeight: BigInt

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -56,4 +56,23 @@ export type AccountWithTransactions = Account & {
   transactions: any[]
 }
 
+export interface SessionHeader {
+  readonly applicationPubKey: string
+  readonly chain: string
+  readonly sessionBlockHeight: bigint
+}
+
+export interface PocketAAT {
+  readonly version: string
+  readonly clientPublicKey: string
+  readonly applicationPublicKey: string
+  readonly applicationSignature: string
+}
+
+export interface Session {
+  readonly sessionHeader: SessionHeader
+  readonly sessionKey: string
+  readonly sessionNodes: Node[]
+}
+
 export {}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -93,6 +93,11 @@ export interface DispatchResponse {
   readonly session: Session
 }
 
+export interface RequestHash {
+  readonly payload: RelayPayload
+  readonly meta: RelayMeta
+}
+
 export interface RelayProof {
   readonly entropy: BigInt
   readonly sessionBlockHeight: BigInt

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,9 +72,9 @@ export interface PocketAAT {
 }
 
 export interface Session {
-  readonly sessionHeader: SessionHeader
-  readonly sessionKey: string
-  readonly sessionNodes: Node[]
+  readonly header: SessionHeader
+  readonly key: string
+  readonly nodes: Node[]
 }
 
 export enum HTTPMethod {
@@ -90,10 +90,7 @@ export interface DispatchRequest {
 
 export interface DispatchResponse {
   readonly blockHeight: BigInt
-  readonly header: SessionHeader
-  readonly key: string
-  readonly nodes: Node[]
-
+  readonly session: Session
 }
 
 export interface RelayProof {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
       typescript: ^4.5.5
     devDependencies:
       prettier: 2.5.1
-      turbo: 1.1.2
+      turbo: 1.1.3
       typescript: 4.5.5
 
   packages/pocket:
@@ -74,6 +74,8 @@ importers:
       '@typescript-eslint/parser': ^5.10.2
       eslint: 7.32.0
       jest: ^27.4.7
+      js-sha256: ^0.9.0
+      js-sha3: ^0.8.0
       microbundle: ^0.14.2
       prettier: ^2.5.1
       prettier-eslint: ^13.0.0
@@ -82,6 +84,8 @@ importers:
       '@pokt-foundation/pocketjs-provider': link:../provider
       '@pokt-foundation/pocketjs-signer': link:../signer
       '@pokt-foundation/pocketjs-types': link:../types
+      js-sha256: 0.9.0
+      js-sha3: 0.8.0
     devDependencies:
       '@types/jest': 27.4.0
       '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f
@@ -4515,6 +4519,14 @@ packages:
       - utf-8-validate
     dev: true
 
+  /js-sha256/0.9.0:
+    resolution: {integrity: sha512-sga3MHh9sgQN2+pJ9VYZ+1LPwXOxuBJBA5nrR5/ofPfuiJBE2hnjsaN8se8JznOmGLN2p49Pe5U/ttafcs/apA==}
+    dev: false
+
+  /js-sha3/0.8.0:
+    resolution: {integrity: sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==}
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -6285,119 +6297,119 @@ packages:
       typescript: 4.5.5
     dev: true
 
-  /turbo-darwin-64/1.1.2:
-    resolution: {integrity: sha512-rua17HnVvAqAU54gVfiQoH7cfopOqANv+yI6NtxLMD8aFfX2cJ9m8SSvH2v2vCaToNDW6OnTkdqDKQpqIHzbCw==}
+  /turbo-darwin-64/1.1.3:
+    resolution: {integrity: sha512-dIJE19hY6FmCoIvXWa6RO85xLWTw0tsDZlOdUAE+EK5YM54G8yIsfZqeVZdn5Iy28oMOvpBoF1TL6936d3zaXQ==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.1.2:
-    resolution: {integrity: sha512-otqSQNYDyKg0KqB3NM0BI4oiRPKdJkUE/XBn8dcUS+zeRLrL00XtaM0eSwynZs1tb6zU/Y+SPMSBRygD1TCOnw==}
+  /turbo-darwin-arm64/1.1.3:
+    resolution: {integrity: sha512-6AtJD0TxtxSiWlgPZbr3OltNbdhjq3Tuowi2sgVdYXB1dEYoHn4l5Fa7Nv5lr72X1OvItmmEcqSLCqi+uBf1PQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-64/1.1.2:
-    resolution: {integrity: sha512-2nxwVDTAM0DtIQ2i3UOfEsQLF7vp+XZ/b9SKtiHxz710fXvdyuGivYI25axDdcBn8kQ45rnbUnarF1aW8CMGgg==}
+  /turbo-freebsd-64/1.1.3:
+    resolution: {integrity: sha512-dzYlYWK/5nwZaABRNwYg9sSNvC2QHcEU3WZdsZwviRsyAG1O4bxStnhR22BAzJs+jxRUrG3W7j1pUY1rqdJ62Q==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-arm64/1.1.2:
-    resolution: {integrity: sha512-ro1Ah96yzgzyT0BJe1mceAqxPxi0pUwzAvN3IKVpMqi4hYkT3aRbzDCaSxzyC6let2Al/NUsgHnbAv38OF2Xkw==}
+  /turbo-freebsd-arm64/1.1.3:
+    resolution: {integrity: sha512-YZ/bBy59/16hEb06G73m5IcuMRCFRZnmEXMMlmfY2B+AR5d103TdenZQ0sxWWRVVQu7FfhT3QsbJ00GcxtrO8Q==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-32/1.1.2:
-    resolution: {integrity: sha512-HKBsETxQMVaf/DJwMg7pypPbGA6KEu0gEf9C8o2aPJvwMPBYgNsNaU08Xizuh5xzEQTzpbIWfQyqdNgMV4RG3Q==}
+  /turbo-linux-32/1.1.3:
+    resolution: {integrity: sha512-BwP8oL9NlhlIFgEqBfsj7ASx5Adzaf1L7Xn9GGhv2v2uD1N8mgAuPyy/X3VUYDdMi6JeHc5gxRKnawJI7uTr9g==}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.1.2:
-    resolution: {integrity: sha512-IklKsOklcRHIWkTzKg95BQ6jgJ53kLvRMrp8yqzlvZprkWdiyhAgUxrUTTHOOTce2XA3+jdN2+MwixG44uY2vg==}
+  /turbo-linux-64/1.1.3:
+    resolution: {integrity: sha512-ZdgaJO45ZHxJStDU6uSSgw1baCB1OatF9YOgx6XByOIeV0etdETFvhTPhSZ/mD9Xsk5QP1SoCjrvTbhk6/FZsg==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm/1.1.2:
-    resolution: {integrity: sha512-CNbaTvRozq7H/5jpy9OZlzJ6BkeEXF+nF2n9dHiUrbAXd3nq84Qt9odcQJmGnexP19YS9w6l3tIHncX4BgwtqA==}
+  /turbo-linux-arm/1.1.3:
+    resolution: {integrity: sha512-ZBce2TXUgt8IPyXcNMlR07fvRLoIh6VhDR+7zbL1tSAtWkOTGQHS0h80B7bg6pQ4IftQqluGc8NkMaNCUmDgaA==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.1.2:
-    resolution: {integrity: sha512-3kS6sk2lOtuBBqkcL+yeGqD1yew4UZ1o7XUcbDD8UPwhF2kAfK7Qs0vTJw4lnO1scjhihkoTrmXM7yozvjf4/w==}
+  /turbo-linux-arm64/1.1.3:
+    resolution: {integrity: sha512-gM9638BGZ2An94cd8w/Q35xCUmo/ZACcQJnmR82pyRUIalk3tmGnKupjn1IFK8yCPdMJ4+zs5SvrLGn/C+ldtQ==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-mips64le/1.1.2:
-    resolution: {integrity: sha512-CDoXVIlW43C6KLgYxe13KkG8h6DswXHxbTVHiZdOwRQ56j46lU+JOVpLoh6wpQGcHvj58VEiypZBRTGVFMeogw==}
+  /turbo-linux-mips64le/1.1.3:
+    resolution: {integrity: sha512-9QmdAq+Yl4iGvUJVbcQ4hMH4BPeXqBtkBAOEiPunbeYtRH4xzQh+bSCYdrH7FfujND82nCKVjXMuGSJO6IyY6g==}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-ppc64le/1.1.2:
-    resolution: {integrity: sha512-xPVMHoiOJE/qI63jSOXwYIUFQXLdstxDV6fLnRxvq0QnJNxgTKq+mLUeE8M4LDVh1bdqHLcfk/HmyQ6+X1XVkQ==}
+  /turbo-linux-ppc64le/1.1.3:
+    resolution: {integrity: sha512-CwWh9V5Cqh4TR8E7mAR2+WLlsyJcLkZzZ6GQdS8rovVveKPII2VpTihMXkGyvwCxO/pQmOHwCaVUzgxIGtQrDQ==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-32/1.1.2:
-    resolution: {integrity: sha512-Gj1yvPE0aMDSOxGVSBaecLnwsVDT1xX8U0dtLrg52TYY2jlaci0atjHKr9nTFuX7z8uwAf6PopwdriGoCeT3ng==}
+  /turbo-windows-32/1.1.3:
+    resolution: {integrity: sha512-/qJoU6P8pBZrTdxiV4yUxyc1yVBJdsZunP9vYuF7tz/3DCaJujnZhmYOn+vcA2fUe9wwk/s7e2eg7LG5qsREFA==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.1.2:
-    resolution: {integrity: sha512-0Ncx/iKhnKrdAU8hJ+8NUcF9jtFr8KoW5mMWfiFzy+mgUbVKbpzWT2eoGR6zJExedQsRvYOejbEX5iihbnj5bA==}
+  /turbo-windows-64/1.1.3:
+    resolution: {integrity: sha512-tWXUrKUL1Bdx5EekMa0IjonZPjMe1GTHz3/CK3rSI85hkJ/Up52SgcQgkhIs42lMPQiKbrbgISYpVH5c/aLxRw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.1.2:
-    resolution: {integrity: sha512-3ViHKyAkaBKNKwHASTa1zkVT3tVVhQNLrpxBS7LoN+794ouQUYmy6lf0rTqzG3iTZHtIDwC+piZSdTl4XjEVMg==}
+  /turbo/1.1.3:
+    resolution: {integrity: sha512-Za/hHiCxGsC3n4yROy5hHLJkJ5tkq2po5V8L+WBURw7RjAt1C7EP5PMIsLQpXV69Icts9NEZnniVRXEkKGuKfQ==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.1.2
-      turbo-darwin-arm64: 1.1.2
-      turbo-freebsd-64: 1.1.2
-      turbo-freebsd-arm64: 1.1.2
-      turbo-linux-32: 1.1.2
-      turbo-linux-64: 1.1.2
-      turbo-linux-arm: 1.1.2
-      turbo-linux-arm64: 1.1.2
-      turbo-linux-mips64le: 1.1.2
-      turbo-linux-ppc64le: 1.1.2
-      turbo-windows-32: 1.1.2
-      turbo-windows-64: 1.1.2
+      turbo-darwin-64: 1.1.3
+      turbo-darwin-arm64: 1.1.3
+      turbo-freebsd-64: 1.1.3
+      turbo-freebsd-arm64: 1.1.3
+      turbo-linux-32: 1.1.3
+      turbo-linux-64: 1.1.3
+      turbo-linux-arm: 1.1.3
+      turbo-linux-arm64: 1.1.3
+      turbo-linux-mips64le: 1.1.3
+      turbo-linux-ppc64le: 1.1.3
+      turbo-windows-32: 1.1.3
+      turbo-windows-64: 1.1.3
     dev: true
 
   /type-check/0.3.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,7 @@ importers:
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
       eslint: 7.32.0
+      hex-lite: ^1.5.0
       jest: ^27.4.7
       libsodium-wrappers: ^0.7.9
       microbundle: ^0.14.2
@@ -114,6 +115,7 @@ importers:
       '@pokt-foundation/pocketjs-provider': link:../provider
       '@pokt-foundation/pocketjs-types': link:../types
       '@pokt-foundation/pocketjs-utils': link:../utils
+      hex-lite: 1.5.0
       libsodium-wrappers: 0.7.9
     devDependencies:
       '@types/jest': 27.4.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
 
   packages/relayer:
     specifiers:
+      '@pokt-foundation/pocketjs-provider': ^0.0.0
+      '@pokt-foundation/pocketjs-signer': ^0.0.0
+      '@pokt-foundation/pocketjs-types': ^0.0.0
       '@types/jest': ^27.4.0
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
@@ -75,6 +78,10 @@ importers:
       prettier: ^2.5.1
       prettier-eslint: ^13.0.0
       ts-jest: ^27.1.3
+    dependencies:
+      '@pokt-foundation/pocketjs-provider': link:../provider
+      '@pokt-foundation/pocketjs-signer': link:../signer
+      '@pokt-foundation/pocketjs-types': link:../types
     devDependencies:
       '@types/jest': 27.4.0
       '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f


### PR DESCRIPTION
Adds a barebones, working Pocket Relayer implementation that can be used to request new sessions and send relays into the network. A few caveats of the implementation:
- The JSON-RPC provider can take providers optionally now. I might consider making a `RelayProvider` so it's more obvious how to use a provider for sending relays.
- Types still need to be very much tightened up and organized.
- `toJSON` utility functions haven't been implemented.

Sending a relay involves:
- Instantiating a JSON-RPC provider.
- Instantiating a key manager with the account that will sign the relay.
- Getting the AAT.
- Instantiating the relayer.
- Getting a session
- Sending a relay!

```
const provider = new JsonRpcProvider({
  rpcUrl: MAINNET_RPC_URL,
  dispatchers: DISPATCHERS,
});

const signer = await KeyManager.fromPrivateKey(
PRIVATE_KEY
);

const relayer = new Relayer({
  keyManager: signer,
  provider
});

const session = await relayer.getNewSession({
  chain: "0024",
  applicationPubKey: APP_PUB_KEY,
});

const ans = await relayer.relay({
  data: RELAY_DATA,
  blockchain: "0024",
  pocketAAT: aat,
  session: session,
});
```

