### PR TITLE
Provider, Relayer: handle errors more gracefully

### DIFF
--- a/packages/provider/src/errors.ts
+++ b/packages/provider/src/errors.ts
@@ -5,3 +5,11 @@ export class DispatchersFailureError extends Error {
     this.message = 'Failed to obtain a session due to dispatchers failure'
   }
 }
+
+export class RelayFailureError extends Error {
+  constructor(...params: any[]) {
+    super(...params)
+    this.name = 'RelayFailureError'
+    this.message = 'Provider node returned a invalid non JSON response'
+  }
+}

--- a/packages/provider/src/errors.ts
+++ b/packages/provider/src/errors.ts
@@ -1,0 +1,7 @@
+export class DispatchersFailureError extends Error {
+  constructor(...params: any[]) {
+    super(...params)
+    this.name = 'DispatchersFailureError'
+    this.message = 'Failed to obtain a session due to dispatchers failure'
+  }
+}

--- a/packages/provider/src/index.ts
+++ b/packages/provider/src/index.ts
@@ -1,3 +1,4 @@
 export * from './abstract-provider'
+export * from './errors'
 export * from './json-rpc-provider'
 export * from './routes'

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -247,8 +247,8 @@ export class JsonRpcProvider implements AbstractProvider {
       chains,
       publicKey: public_key,
       jailed,
-      maxRelays: BigInt(max_relays ?? 0),
-      stakedTokens: BigInt(staked_tokens ?? 0),
+      maxRelays: max_relays ?? 0,
+      stakedTokens: staked_tokens ?? 0,
       status,
     }
   }
@@ -268,7 +268,7 @@ export class JsonRpcProvider implements AbstractProvider {
 
     return {
       address: await address,
-      balance: BigInt(coins[0]?.amount ?? 0),
+      balance: coins[0]?.amount ?? 0,
       publicKey: public_key,
     }
   }
@@ -299,7 +299,7 @@ export class JsonRpcProvider implements AbstractProvider {
 
     return {
       address: await address,
-      balance: BigInt(coins[0]?.amount ?? 0),
+      balance: coins[0]?.amount ?? 0,
       publicKey: public_key,
       totalCount: total_count,
       transactions: transactions,

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -13,7 +13,7 @@ import {
   TransactionResponse,
 } from '@pokt-foundation/pocketjs-types'
 import { AbstractProvider } from './abstract-provider'
-import { DispatchersFailureError } from './errors'
+import { DispatchersFailureError, RelayFailureError } from './errors'
 import { V1RpcRoutes } from './routes'
 
 export class JsonRpcProvider implements AbstractProvider {
@@ -381,8 +381,13 @@ export class JsonRpcProvider implements AbstractProvider {
       rpcUrl,
     })
 
-    const relayResponse = (await relayAttempt?.json()) ?? relayAttempt
+    try {
+      const relayResponse = await relayAttempt.json()
 
-    return relayResponse
+      return relayResponse
+    } catch (err) {
+      console.log(err)
+      throw new RelayFailureError()
+    }
   }
 }

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -215,7 +215,7 @@ export class JsonRpcProvider implements AbstractProvider {
       publicKey: public_key,
       jailed,
       serviceUrl: service_url,
-      stakedTokens: BigInt(tokens),
+      stakedTokens: tokens.toString(),
       status,
       unstakingTime: unstaking_time,
     }
@@ -348,7 +348,7 @@ export class JsonRpcProvider implements AbstractProvider {
           publicKey: public_key,
           jailed,
           serviceUrl: service_url,
-          stakedTokens: BigInt(tokens),
+          stakedTokens: tokens.toString(),
           status,
           unstakingTime: unstaking_time,
         } as Node
@@ -380,8 +380,7 @@ export class JsonRpcProvider implements AbstractProvider {
       rpcUrl,
     })
 
-    const relayResponse =
-      (await relayAttempt?.json()) ?? relayAttempt
+    const relayResponse = (await relayAttempt?.json()) ?? relayAttempt
 
     return relayResponse
   }

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -3,16 +3,17 @@ import {
   Account,
   AccountWithTransactions,
   App,
-  Node,
   Block,
-  GetAppOptions,
-  GetNodesOptions,
-  TransactionResponse,
   DispatchRequest,
   DispatchResponse,
+  GetAppOptions,
+  GetNodesOptions,
+  Node,
   SessionHeader,
+  TransactionResponse,
 } from '@pokt-foundation/pocketjs-types'
 import { AbstractProvider } from './abstract-provider'
+import { DispatchersFailureError } from './errors'
 import { V1RpcRoutes } from './routes'
 
 export class JsonRpcProvider implements AbstractProvider {
@@ -369,7 +370,7 @@ export class JsonRpcProvider implements AbstractProvider {
         },
       }
     } catch (err) {
-      throw new Error('Failed to obtain a session due to dispatchers failure.')
+      throw new DispatchersFailureError()
     }
   }
 

--- a/packages/relayer/src/errors.ts
+++ b/packages/relayer/src/errors.ts
@@ -7,6 +7,7 @@ export enum PocketCoreErrorCodes {
   OverServiceError = 71,
   RequestHashError = 74,
   UnsupportedBlockchainError = 76,
+  HTTPExecutionError = 28
 }
 
 export class PocketCoreError extends Error {
@@ -76,6 +77,13 @@ export class OverServiceError extends PocketCoreError {
   }
 }
 
+export class HTTPExecutionError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, message, ...params)
+    this.name = 'HTTPExecutionError'
+  }
+}
+
 export function validateRelayResponse(relayResponse: any) {
   if ('response' in relayResponse && 'signature' in relayResponse) {
     return relayResponse.response
@@ -125,6 +133,11 @@ export function validateRelayResponse(relayResponse: any) {
     case PocketCoreErrorCodes.UnsupportedBlockchainError:
       throw new UnsupportedBlockchainError(
         PocketCoreErrorCodes.UnsupportedBlockchainError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.HTTPExecutionError:
+      throw new UnsupportedBlockchainError(
+        PocketCoreErrorCodes.HTTPExecutionError,
         relayResponse.error.message
       )
     default:

--- a/packages/relayer/src/errors.ts
+++ b/packages/relayer/src/errors.ts
@@ -136,7 +136,7 @@ export function validateRelayResponse(relayResponse: any) {
         relayResponse.error.message
       )
     case PocketCoreErrorCodes.HTTPExecutionError:
-      throw new UnsupportedBlockchainError(
+      throw new HTTPExecutionError(
         PocketCoreErrorCodes.HTTPExecutionError,
         relayResponse.error.message
       )

--- a/packages/relayer/src/index.ts
+++ b/packages/relayer/src/index.ts
@@ -1,2 +1,3 @@
 export * from './abstract-relayer'
 export * from './relayer'
+export * from './errors'

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -148,19 +148,19 @@ export class Relayer implements AbstractRelayer {
       serviceNode.serviceUrl.toString()
     )
 
-    const relayResponse = validateRelayResponse(relay)
+    const relayResponse = await validateRelayResponse(relay)
 
     return {
       response: relayResponse,
       relayProof: {
         entropy: relayProof.entropy,
         sessionBlockheight: relayProof.session_block_height,
-        servicer_pub_key: servicerPubKey,
+        servicerPubKey: servicerPubKey,
         blockchain,
         aat: {
           version: pocketAAT.version,
-          app_pub_key: pocketAAT.applicationPublicKey,
-          client_pub_key: pocketAAT.clientPublicKey,
+          appPubKey: pocketAAT.applicationPublicKey,
+          clientPubKey: pocketAAT.clientPublicKey,
           signature: pocketAAT.applicationSignature,
         },
         signature: signedProofBytes,

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -154,7 +154,24 @@ export class Relayer implements AbstractRelayer {
 
     const relayResponse = validateRelayResponse(relay)
 
-    return relayResponse
+    return {
+      response: relayResponse,
+      relayProof: {
+        entropy: relayProof.entropy,
+        sessionBlockheight: relayProof.session_block_height,
+        servicer_pub_key: servicerPubKey,
+        blockchain,
+        aat: {
+          version: pocketAAT.version,
+          app_pub_key: pocketAAT.applicationPublicKey,
+          client_pub_key: pocketAAT.clientPublicKey,
+          signature: pocketAAT.applicationSignature,
+        },
+        signature: signedProofBytes,
+        requestHash: this.hashRequest(requestHash),
+      },
+      serviceNode,
+    }
   }
 
   async relay({

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -6,12 +6,8 @@ import {
   Node,
   PocketAAT,
   RelayHeaders,
-  RelayMeta,
   RelayPayload,
-  RelayResponse,
-  RequestHash,
   Session,
-  SessionHeader,
 } from '@pokt-foundation/pocketjs-types'
 import { AbstractRelayer } from './abstract-relayer'
 import { validateRelayResponse } from './errors'

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -39,7 +39,7 @@ export interface Node {
   jailed: boolean
   publicKey: string
   serviceUrl: string
-  stakedTokens: bigint
+  stakedTokens: string
   status: StakingStatus
   unstakingTime: string
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,10 +1,10 @@
 /* eslint-disable @typescript-eslint/no-empty-interface */
 export interface TransactionResponse {
-  code?: BigInt
+  code?: number
   codeSpace?: string
   data?: string
   hash: string
-  height: BigInt
+  height: number
   info?: string
   rawLog?: string
   timestamp?: string
@@ -27,9 +27,9 @@ export interface App {
   address: string
   chains: string[]
   jailed: boolean
-  maxRelays: bigint
+  maxRelays: string
   publicKey: string
-  stakedTokens: bigint
+  stakedTokens: string
   status: StakingStatus
 }
 
@@ -46,7 +46,7 @@ export interface Node {
 
 export interface Account {
   address: string
-  balance: bigint
+  balance: string
   publicKey: null | string
 }
 
@@ -89,7 +89,7 @@ export interface DispatchRequest {
 }
 
 export interface DispatchResponse {
-  readonly blockHeight: BigInt
+  readonly blockHeight: number
   readonly session: Session
 }
 
@@ -99,8 +99,8 @@ export interface RequestHash {
 }
 
 export interface RelayProof {
-  readonly entropy: BigInt
-  readonly sessionBlockHeight: BigInt
+  readonly entropy: string
+  readonly sessionBlockHeight: number
   readonly servicerPubKey: string
   readonly blockchain: string
   readonly token: PocketAAT
@@ -116,7 +116,7 @@ export interface RelayPayload {
 }
 
 export interface RelayMeta {
-  readonly blockHeight: bigint
+  readonly blockHeight: string
 }
 
 export interface RelayRequest {


### PR DESCRIPTION
Handles dispatcher failures more gracefully. Previously we were returning whatever junk the node returned, but that's a bit unwieldy for usage. This returns a more generic error that can be easily watched on the Portal API and any other consuming client and handled appropriately.