### PR TITLE
Provider, Relayer: Timeout implementation

### DIFF
--- a/packages/provider/src/errors.ts
+++ b/packages/provider/src/errors.ts
@@ -13,3 +13,11 @@ export class RelayFailureError extends Error {
     this.message = 'Provider node returned a invalid non JSON response'
   }
 }
+
+export class TimeoutError extends Error {
+  constructor(...params: any[]) {
+    super(...params)
+    this.name = 'TimeoutError'
+    this.message = 'Provider timed out during request'
+  }
+}

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -382,11 +382,16 @@ export class JsonRpcProvider implements AbstractProvider {
     }
   }
 
-  async relay(request, rpcUrl: string): Promise<unknown> {
+  async relay(
+    request,
+    rpcUrl: string,
+    { timeout }: { timeout?: number } = { timeout: DEFAULT_TIMEOUT }
+  ): Promise<unknown> {
     const relayAttempt = await this.perform({
       route: V1RpcRoutes.ClientRelay,
       body: request,
       rpcUrl,
+      timeout,
     })
 
     try {

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -16,6 +16,8 @@ import { AbstractProvider } from './abstract-provider'
 import { DispatchersFailureError, RelayFailureError } from './errors'
 import { V1RpcRoutes } from './routes'
 
+const DEFAULT_TIMEOUT = 5000
+
 export class JsonRpcProvider implements AbstractProvider {
   private rpcUrl: string
   private dispatchers: string[]
@@ -35,11 +37,16 @@ export class JsonRpcProvider implements AbstractProvider {
     route,
     body,
     rpcUrl,
+    timeout = DEFAULT_TIMEOUT,
   }: {
     route: V1RpcRoutes
     body: any
     rpcUrl?: string
+    timeout?: number
   }): Promise<Response> {
+    const controller = new AbortController()
+    setTimeout(() => controller.abort(), timeout)
+
     const finalRpcUrl = rpcUrl
       ? rpcUrl
       : route === V1RpcRoutes.ClientDispatch
@@ -51,6 +58,7 @@ export class JsonRpcProvider implements AbstractProvider {
     try {
       const rpcResponse = await fetch(`${finalRpcUrl}${route}`, {
         method: 'POST',
+        signal: controller.signal,
         headers: {
           'Content-Type': 'application/json',
         },

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -12,6 +12,8 @@ import {
 import { AbstractRelayer } from './abstract-relayer'
 import { validateRelayResponse } from './errors'
 
+const DEFAULT_RELAYER_TIMEOUT = 5000
+
 export class Relayer implements AbstractRelayer {
   readonly keyManager: KeyManager | AbstractSigner
   readonly provider: JsonRpcProvider
@@ -64,17 +66,19 @@ export class Relayer implements AbstractRelayer {
     pocketAAT,
     provider,
     session,
+    timeout = DEFAULT_RELAYER_TIMEOUT
   }: {
-    data: string
     blockchain: string
-    pocketAAT: PocketAAT
-    provider: JsonRpcProvider
-    keyManager: KeyManager | AbstractSigner
+    data: string
     headers?: RelayHeaders | null
+    keyManager: KeyManager | AbstractSigner
     method: HTTPMethod | ''
-    session: Session
     node: Node
     path: string
+    pocketAAT: PocketAAT
+    provider: JsonRpcProvider
+    session: Session
+    timeout?: number
   }) {
     if (!keyManager) {
       throw new Error('You need a signer to send a relay')
@@ -179,6 +183,7 @@ export class Relayer implements AbstractRelayer {
     path = '',
     pocketAAT,
     session,
+    timeout = DEFAULT_RELAYER_TIMEOUT,
   }: {
     data: string
     blockchain: string
@@ -188,6 +193,7 @@ export class Relayer implements AbstractRelayer {
     session: Session
     node: Node
     path: string
+    timeout?: number
   }) {
     if (!this.keyManager) {
       throw new Error('You need a signer to send a relay')

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -66,7 +66,7 @@ export class Relayer implements AbstractRelayer {
     pocketAAT,
     provider,
     session,
-    timeout = DEFAULT_RELAYER_TIMEOUT
+    timeout = DEFAULT_RELAYER_TIMEOUT,
   }: {
     blockchain: string
     data: string

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -44,13 +44,17 @@ export class Relayer implements AbstractRelayer {
       timeout?: number
     }
   }): Promise<Session> {
-    const dispatchResponse = await this.provider.dispatch({
-      sessionHeader: {
-        applicationPubKey: applicationPubKey ?? this.keyManager.getPublicKey(),
-        chain,
-        sessionBlockHeight: sessionBlockHeight ?? 0,
+    const dispatchResponse = await this.provider.dispatch(
+      {
+        sessionHeader: {
+          applicationPubKey:
+            applicationPubKey ?? this.keyManager.getPublicKey(),
+          chain,
+          sessionBlockHeight: sessionBlockHeight ?? 0,
+        },
       },
-    })
+      options
+    )
 
     return dispatchResponse.session as Session
   }
@@ -149,7 +153,8 @@ export class Relayer implements AbstractRelayer {
 
     const relay = await provider.relay(
       relayRequest,
-      serviceNode.serviceUrl.toString()
+      serviceNode.serviceUrl.toString(),
+      { timeout }
     )
 
     const relayResponse = await validateRelayResponse(relay)


### PR DESCRIPTION
Implements a temporal API for timeouts for the relayer and provider specifically. It's subject to change, but should be enough to let the Portal API roll out the new SDK for testing.