### PR TITLE
Relayer: Add custom session/node-related errors

### DIFF
--- a/packages/relayer/src/errors.ts
+++ b/packages/relayer/src/errors.ts
@@ -1,13 +1,38 @@
+export class ServiceNodeNotInSessionError extends Error {
+  constructor(message: string, ...params: any[]) {
+    super(...params)
+    this.message = message
+    this.name = 'ServiceNodeNotInSessionError'
+  }
+}
+
+export class EmptyKeyManagerError extends Error {
+  constructor(message: string, ...params: any[]) {
+    super(...params)
+    this.message = message
+    this.name = 'EmptyKeyManagerError'
+  }
+}
+
+export class NoServiceNodeError extends Error {
+  constructor(message: string, ...params: any[]) {
+    super(...params)
+    this.message = message
+    this.name = 'NoServiceNodeError'
+  }
+}
+
 export enum PocketCoreErrorCodes {
   AppNotFoundError = 45,
   DuplicateProofError = 37,
   EmptyPayloadDataError = 25,
   EvidenceSealedError = 90,
+  HTTPExecutionError = 28,
   InvalidBlockHeightError = 60,
+  InvalidSessionError = 14,
   OverServiceError = 71,
   RequestHashError = 74,
   UnsupportedBlockchainError = 76,
-  HTTPExecutionError = 28
 }
 
 export class PocketCoreError extends Error {
@@ -46,6 +71,13 @@ export class InvalidBlockHeightError extends PocketCoreError {
   constructor(code: number, message: string, ...params: any[]) {
     super(code, message, ...params)
     this.name = 'InvalidBlockHeightError'
+  }
+}
+
+export class InvalidSessionError extends PocketCoreError {
+  constructor(code: number, message: string, ...params: any[]) {
+    super(code, message, ...params)
+    this.name = 'InvalidSessionError'
   }
 }
 
@@ -138,6 +170,11 @@ export function validateRelayResponse(relayResponse: any) {
     case PocketCoreErrorCodes.HTTPExecutionError:
       throw new HTTPExecutionError(
         PocketCoreErrorCodes.HTTPExecutionError,
+        relayResponse.error.message
+      )
+    case PocketCoreErrorCodes.InvalidSessionError:
+      throw new InvalidSessionError(
+        PocketCoreErrorCodes.InvalidSessionError,
         relayResponse.error.message
       )
     default:

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -10,7 +10,12 @@ import {
   Session,
 } from '@pokt-foundation/pocketjs-types'
 import { AbstractRelayer } from './abstract-relayer'
-import { validateRelayResponse } from './errors'
+import {
+  EmptyKeyManagerError,
+  NoServiceNodeError,
+  ServiceNodeNotInSessionError,
+  validateRelayResponse,
+} from './errors'
 
 const DEFAULT_RELAYER_TIMEOUT = 5000
 
@@ -85,17 +90,19 @@ export class Relayer implements AbstractRelayer {
     timeout?: number
   }) {
     if (!keyManager) {
-      throw new Error('You need a signer to send a relay')
+      throw new EmptyKeyManagerError('You need a signer to send a relay')
     }
 
     const serviceNode = node ?? Relayer.getRandomSessionNode(session)
 
     if (!serviceNode) {
-      throw new Error(`Couldn't find a service node.`)
+      throw new NoServiceNodeError(`Couldn't find a service node to use.`)
     }
 
     if (!this.isNodeInSession(session, serviceNode)) {
-      throw new Error(`Node is not in the current session`)
+      throw new ServiceNodeNotInSessionError(
+        `Provided node is not in the current session`
+      )
     }
 
     const servicerPubKey = serviceNode.publicKey


### PR DESCRIPTION
Adds errors mainly related to pre-relay sending, such as getting a service node (or confirming it's in the session), and a Pocket Core related error for an invalid session.