### PR TITLE
Provider(JsonRpcProvider): Add retries to rpc calls

### DIFF
--- a/packages/provider/src/errors.ts
+++ b/packages/provider/src/errors.ts
@@ -10,7 +10,7 @@ export class RelayFailureError extends Error {
   constructor(...params: any[]) {
     super(...params)
     this.name = 'RelayFailureError'
-    this.message = 'Provider node returned a invalid non JSON response'
+    this.message = 'Provider node returned an invalid non JSON response'
   }
 }
 

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -43,23 +43,23 @@ export class JsonRpcProvider implements AbstractProvider {
     rpcUrl,
     timeout = DEFAULT_TIMEOUT,
     retryAttempts = 0,
-    attemptsPerformed = 1
+    retriesPerformed = 0
   }: {
     route: V1RpcRoutes
     body: any
     rpcUrl?: string
     timeout?: number,
     retryAttempts?: number,
-    attemptsPerformed?: number
+    retriesPerformed?: number
   }): Promise<Response> {
-    const shouldRetryOnFailure = attemptsPerformed < retryAttempts
+    const shouldRetryOnFailure = retriesPerformed < retryAttempts
     const performRetry = () => this.perform({
       route,
       body,
       rpcUrl,
       timeout,
       retryAttempts,
-      attemptsPerformed: attemptsPerformed + 1
+      retriesPerformed: retriesPerformed + 1
     })
 
     const controller = new AbortController()
@@ -88,6 +88,8 @@ export class JsonRpcProvider implements AbstractProvider {
       }
     })
 
+    // Fetch can fail by either throwing due to a network error or responding with
+    // ok === false on 40x/50x so both situations be explicitly handled separately. 
     return (!rpcResponse.ok && shouldRetryOnFailure) ? performRetry() : rpcResponse
   }
 

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -223,6 +223,7 @@ export class Relayer implements AbstractRelayer {
       session,
       keyManager: this.keyManager,
       provider: this.provider,
+      timeout
     })
   }
 


### PR DESCRIPTION
Adds the ability to perform  retries on rpc calls recursively until the `retryAttempts` is exceeded. The argument defaults to 0 so rpc calls that wants to take advantage of this should explicitly expose the argument to the client. Currently only used by the `getNewSession` function.

On a small side note added the timeout limit to the relay call as it was only passing the unused argument, let me know if that should be separate.