### PR TITLE
Monorepo: use workspace linking protocol

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -20,7 +20,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "@pokt-foundation/pocketjs-types": "^0.0.0",
+    "@pokt-foundation/pocketjs-types": "workspace:*",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -31,7 +31,7 @@
     "ts-jest": "^27.1.3"
   },
   "dependencies": {
-    "@pokt-foundation/pocketjs-provider": "^0.0.2",
+    "@pokt-foundation/pocketjs-provider": "workspace:*",
     "@pokt-foundation/pocketjs-signer": "^0.0.0",
     "@pokt-foundation/pocketjs-types": "^0.0.0",
     "js-sha256": "^0.9.0",

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -32,8 +32,8 @@
   },
   "dependencies": {
     "@pokt-foundation/pocketjs-provider": "workspace:*",
-    "@pokt-foundation/pocketjs-signer": "^0.0.0",
-    "@pokt-foundation/pocketjs-types": "^0.0.0",
+    "@pokt-foundation/pocketjs-signer": "workspace:*",
+    "@pokt-foundation/pocketjs-types": "workspace:*",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0"
   }

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
+    "@pokt-foundation/pocketjs-types": "workspace:*",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
@@ -33,7 +34,6 @@
   "dependencies": {
     "@pokt-foundation/pocketjs-provider": "workspace:*",
     "@pokt-foundation/pocketjs-signer": "workspace:*",
-    "@pokt-foundation/pocketjs-types": "workspace:*",
     "js-sha256": "^0.9.0",
     "js-sha3": "^0.8.0"
   }

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -20,6 +20,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@pokt-foundation/pocketjs-types": "workspace:*",
     "@types/jest": "^27.4.0",
     "@typescript-eslint/eslint-plugin": "^5.10.2",
     "@typescript-eslint/parser": "^5.10.2",
@@ -33,7 +34,6 @@
   "dependencies": {
     "@noble/ed25519": "^1.5.3",
     "@pokt-foundation/pocketjs-provider": "workspace:*",
-    "@pokt-foundation/pocketjs-types": "workspace:*",
     "@pokt-foundation/pocketjs-utils": "workspace:*",
     "hex-lite": "^1.5.0",
     "libsodium-wrappers": "^0.7.9"

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -32,9 +32,9 @@
   },
   "dependencies": {
     "@noble/ed25519": "^1.5.3",
-    "@pokt-foundation/pocketjs-provider": "^0.0.0",
-    "@pokt-foundation/pocketjs-types": "^0.0.0",
-    "@pokt-foundation/pocketjs-utils": "^0.0.0",
+    "@pokt-foundation/pocketjs-provider": "workspace:*",
+    "@pokt-foundation/pocketjs-types": "workspace:*",
+    "@pokt-foundation/pocketjs-utils": "workspace:*",
     "hex-lite": "^1.5.0",
     "libsodium-wrappers": "^0.7.9"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,8 +67,8 @@ importers:
   packages/relayer:
     specifiers:
       '@pokt-foundation/pocketjs-provider': workspace:*
-      '@pokt-foundation/pocketjs-signer': ^0.0.0
-      '@pokt-foundation/pocketjs-types': ^0.0.0
+      '@pokt-foundation/pocketjs-signer': workspace:*
+      '@pokt-foundation/pocketjs-types': workspace:*
       '@types/jest': ^27.4.0
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
@@ -82,8 +82,8 @@ importers:
       ts-jest: ^27.1.3
     dependencies:
       '@pokt-foundation/pocketjs-provider': link:../provider
-      '@pokt-foundation/pocketjs-signer': 0.0.0
-      '@pokt-foundation/pocketjs-types': 0.0.0
+      '@pokt-foundation/pocketjs-signer': link:../signer
+      '@pokt-foundation/pocketjs-types': link:../types
       js-sha256: 0.9.0
       js-sha3: 0.8.0
     devDependencies:
@@ -100,9 +100,9 @@ importers:
   packages/signer:
     specifiers:
       '@noble/ed25519': ^1.5.3
-      '@pokt-foundation/pocketjs-provider': ^0.0.0
-      '@pokt-foundation/pocketjs-types': ^0.0.0
-      '@pokt-foundation/pocketjs-utils': ^0.0.0
+      '@pokt-foundation/pocketjs-provider': workspace:*
+      '@pokt-foundation/pocketjs-types': workspace:*
+      '@pokt-foundation/pocketjs-utils': workspace:*
       '@types/jest': ^27.4.0
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
@@ -116,9 +116,9 @@ importers:
       typescript: ^4.5.5
     dependencies:
       '@noble/ed25519': 1.5.3
-      '@pokt-foundation/pocketjs-provider': 0.0.0
-      '@pokt-foundation/pocketjs-types': 0.0.0
-      '@pokt-foundation/pocketjs-utils': 0.0.0
+      '@pokt-foundation/pocketjs-provider': link:../provider
+      '@pokt-foundation/pocketjs-types': link:../types
+      '@pokt-foundation/pocketjs-utils': link:../utils
       hex-lite: 1.5.0
       libsodium-wrappers: 0.7.9
     devDependencies:
@@ -1777,31 +1777,9 @@ packages:
       webcrypto-core: 1.4.0
     dev: false
 
-  /@pokt-foundation/pocketjs-provider/0.0.0:
-    resolution: {integrity: sha512-We50PgT6/IwFA1rnGKFltlRb+1boeD7BhdE+Zsfii48wCZ4KjseTddnQg7fn0dd2hD48E4Olq6Ig4u473eW4kg==}
-    dependencies:
-      isomorphic-unfetch: 3.1.0
-    transitivePeerDependencies:
-      - encoding
-    dev: false
-
-  /@pokt-foundation/pocketjs-signer/0.0.0:
-    resolution: {integrity: sha512-pnxSYToQZeK6hdFiQ2yGnPBvr+6pRv7rWhsKFkerhWB4p/HxvV4CcXISHyNgZuGzGUv/mTI29pW73c2jMOYsVw==}
-    dependencies:
-      '@noble/ed25519': 1.5.3
-      '@pokt-foundation/pocketjs-provider': 0.0.0
-      '@pokt-foundation/pocketjs-types': 0.0.0
-      '@pokt-foundation/pocketjs-utils': 0.0.0
-      hex-lite: 1.5.0
-      libsodium-wrappers: 0.7.9
-    transitivePeerDependencies:
-      - encoding
-      - expo
-      - react-native
-    dev: false
-
   /@pokt-foundation/pocketjs-types/0.0.0:
     resolution: {integrity: sha512-RQ5Jsmwv0UyIS5iuSWaMW2xOts6OnqAqrurPPJghDEK+9sJt1/BzPR1QOSP/qjg9kWwtvf3KeHREn0tYjzZcPg==}
+    dev: true
 
   /@pokt-foundation/pocketjs-utils/0.0.0:
     resolution: {integrity: sha512-zyPRqDPcUyzEGTsxPd7LPuHPpFq6AcUZ0KCyb+s66i/w93jKA8h6XSC++4XTAShUkDq0bJigteIXRFjKbLKPCg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ importers:
       typescript: ^4.5.5
     devDependencies:
       prettier: 2.5.1
-      turbo: 1.1.3
+      turbo: 1.1.4
       typescript: 4.5.5
 
   packages/pocket:
@@ -66,7 +66,7 @@ importers:
 
   packages/relayer:
     specifiers:
-      '@pokt-foundation/pocketjs-provider': ^0.0.2
+      '@pokt-foundation/pocketjs-provider': workspace:*
       '@pokt-foundation/pocketjs-signer': ^0.0.0
       '@pokt-foundation/pocketjs-types': ^0.0.0
       '@types/jest': ^27.4.0
@@ -6312,119 +6312,119 @@ packages:
       typescript: 4.5.5
     dev: true
 
-  /turbo-darwin-64/1.1.3:
-    resolution: {integrity: sha512-dIJE19hY6FmCoIvXWa6RO85xLWTw0tsDZlOdUAE+EK5YM54G8yIsfZqeVZdn5Iy28oMOvpBoF1TL6936d3zaXQ==}
+  /turbo-darwin-64/1.1.4:
+    resolution: {integrity: sha512-X10dAxqCMXnDjyN4K5mSvhol42kfAcJhI9NS7neIMD25kLcULYFe96Qk1XWEBxgCEBAmkf7UrysYSP+dQMPlGw==}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-darwin-arm64/1.1.3:
-    resolution: {integrity: sha512-6AtJD0TxtxSiWlgPZbr3OltNbdhjq3Tuowi2sgVdYXB1dEYoHn4l5Fa7Nv5lr72X1OvItmmEcqSLCqi+uBf1PQ==}
+  /turbo-darwin-arm64/1.1.4:
+    resolution: {integrity: sha512-sl5TiMLNqWKvKpQsh6lg2sUXRTVt5lfRqnStVw/E/5BTm/KIBZTNWHmx0hO8/LwDmXenVtpiW7h7BbWewfPqTQ==}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-64/1.1.3:
-    resolution: {integrity: sha512-dzYlYWK/5nwZaABRNwYg9sSNvC2QHcEU3WZdsZwviRsyAG1O4bxStnhR22BAzJs+jxRUrG3W7j1pUY1rqdJ62Q==}
+  /turbo-freebsd-64/1.1.4:
+    resolution: {integrity: sha512-EKrAzIyVgmeQf0NpAcxYrhFEiBTrjO163dpiiHxwRiRxTYtcWgY+RJiWVQyIeG0yPx1Z+aLXvmPqf6HvC0T3hg==}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-freebsd-arm64/1.1.3:
-    resolution: {integrity: sha512-YZ/bBy59/16hEb06G73m5IcuMRCFRZnmEXMMlmfY2B+AR5d103TdenZQ0sxWWRVVQu7FfhT3QsbJ00GcxtrO8Q==}
+  /turbo-freebsd-arm64/1.1.4:
+    resolution: {integrity: sha512-Vz3NSbc909eZU1DaS54vL1Z022OCG9wnrK7cB2e2ynMMdeYrIxAWnQeGVrYewQHYhwcCs7/6TgZCfhZKnG2nxQ==}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-32/1.1.3:
-    resolution: {integrity: sha512-BwP8oL9NlhlIFgEqBfsj7ASx5Adzaf1L7Xn9GGhv2v2uD1N8mgAuPyy/X3VUYDdMi6JeHc5gxRKnawJI7uTr9g==}
+  /turbo-linux-32/1.1.4:
+    resolution: {integrity: sha512-sACZPPv0wDpoTu1qRuOP0CYZS6HY8naySg9fTBP4kcRF5dLC4xPQZA46g8AUMkRFoBsyqA08t2whwV8gvYFoUg==}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-64/1.1.3:
-    resolution: {integrity: sha512-ZdgaJO45ZHxJStDU6uSSgw1baCB1OatF9YOgx6XByOIeV0etdETFvhTPhSZ/mD9Xsk5QP1SoCjrvTbhk6/FZsg==}
+  /turbo-linux-64/1.1.4:
+    resolution: {integrity: sha512-VTDSlTiF01P50JcyemWhGC1lx736gQMi3q6eLkGrt0t9HTtkl9FpQEypJDyRKZXTL+60ldriIwhivHmWm9cwQA==}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm/1.1.3:
-    resolution: {integrity: sha512-ZBce2TXUgt8IPyXcNMlR07fvRLoIh6VhDR+7zbL1tSAtWkOTGQHS0h80B7bg6pQ4IftQqluGc8NkMaNCUmDgaA==}
+  /turbo-linux-arm/1.1.4:
+    resolution: {integrity: sha512-XDVX6rzRr7AgqQvA4VwPVAHWxxWFI8SgEsNtbXD4sKiEFo9fTWqMvtRJqhx86Z/XHtCJF8VuU3yPS5puItdc9A==}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-arm64/1.1.3:
-    resolution: {integrity: sha512-gM9638BGZ2An94cd8w/Q35xCUmo/ZACcQJnmR82pyRUIalk3tmGnKupjn1IFK8yCPdMJ4+zs5SvrLGn/C+ldtQ==}
+  /turbo-linux-arm64/1.1.4:
+    resolution: {integrity: sha512-rMSjwzWg9W8J/JwIBtp0+e8O8MP6Z5U4htMgk88zalhSYhAxGIhOCIQT8KsaKoc71Ee/wG1soeprZvqBf/B84Q==}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-mips64le/1.1.3:
-    resolution: {integrity: sha512-9QmdAq+Yl4iGvUJVbcQ4hMH4BPeXqBtkBAOEiPunbeYtRH4xzQh+bSCYdrH7FfujND82nCKVjXMuGSJO6IyY6g==}
+  /turbo-linux-mips64le/1.1.4:
+    resolution: {integrity: sha512-2VK+R9eUQU1xPJ+tGOsALQ6hsc8W7h9ohIumBYYs++SDazwaMQB7lsusXDasf6smEzD02KyUJuj0OvwzJjqq7Q==}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-linux-ppc64le/1.1.3:
-    resolution: {integrity: sha512-CwWh9V5Cqh4TR8E7mAR2+WLlsyJcLkZzZ6GQdS8rovVveKPII2VpTihMXkGyvwCxO/pQmOHwCaVUzgxIGtQrDQ==}
+  /turbo-linux-ppc64le/1.1.4:
+    resolution: {integrity: sha512-Ja9eiRxjioO1PV+TxRmTzsNvGGUQDdJnTLsG1YkKldkplecQdUfJRFdWksEZ7dZ+Hv44g4zvskJgUuCYlGckyA==}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-32/1.1.3:
-    resolution: {integrity: sha512-/qJoU6P8pBZrTdxiV4yUxyc1yVBJdsZunP9vYuF7tz/3DCaJujnZhmYOn+vcA2fUe9wwk/s7e2eg7LG5qsREFA==}
+  /turbo-windows-32/1.1.4:
+    resolution: {integrity: sha512-c8l91hmpsFcmZQJBsDlhLAxfaBl83DXSmDOQoE7YT60vOZZSkfPlNSsHm9tq+4WN54unFfqpNbO7r6z+6R7rfw==}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo-windows-64/1.1.3:
-    resolution: {integrity: sha512-tWXUrKUL1Bdx5EekMa0IjonZPjMe1GTHz3/CK3rSI85hkJ/Up52SgcQgkhIs42lMPQiKbrbgISYpVH5c/aLxRw==}
+  /turbo-windows-64/1.1.4:
+    resolution: {integrity: sha512-DMitFYd5eIhZ2CyPUeds3JXDB/onXBdA2DEj9cxVXY7q2ZBE4rpoV0Ft/mh15LsQZhwap9ipgddbCn16OGFvzw==}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
     dev: true
     optional: true
 
-  /turbo/1.1.3:
-    resolution: {integrity: sha512-Za/hHiCxGsC3n4yROy5hHLJkJ5tkq2po5V8L+WBURw7RjAt1C7EP5PMIsLQpXV69Icts9NEZnniVRXEkKGuKfQ==}
+  /turbo/1.1.4:
+    resolution: {integrity: sha512-kz08AV61hJeY9xuL4yQ27G2qks5LMAdvbd36GpcKvrh4Za+m0t+r2ijMjDvATp8uj4i6IlSV0t/G0/OMwkm6HA==}
     hasBin: true
     requiresBuild: true
     optionalDependencies:
-      turbo-darwin-64: 1.1.3
-      turbo-darwin-arm64: 1.1.3
-      turbo-freebsd-64: 1.1.3
-      turbo-freebsd-arm64: 1.1.3
-      turbo-linux-32: 1.1.3
-      turbo-linux-64: 1.1.3
-      turbo-linux-arm: 1.1.3
-      turbo-linux-arm64: 1.1.3
-      turbo-linux-mips64le: 1.1.3
-      turbo-linux-ppc64le: 1.1.3
-      turbo-windows-32: 1.1.3
-      turbo-windows-64: 1.1.3
+      turbo-darwin-64: 1.1.4
+      turbo-darwin-arm64: 1.1.4
+      turbo-freebsd-64: 1.1.4
+      turbo-freebsd-arm64: 1.1.4
+      turbo-linux-32: 1.1.4
+      turbo-linux-64: 1.1.4
+      turbo-linux-arm: 1.1.4
+      turbo-linux-arm64: 1.1.4
+      turbo-linux-mips64le: 1.1.4
+      turbo-linux-ppc64le: 1.1.4
+      turbo-windows-32: 1.1.4
+      turbo-windows-64: 1.1.4
     dev: true
 
   /type-check/0.3.2:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,7 +39,7 @@ importers:
 
   packages/provider:
     specifiers:
-      '@pokt-foundation/pocketjs-types': ^0.0.0
+      '@pokt-foundation/pocketjs-types': workspace:*
       '@types/jest': ^27.4.0
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
@@ -53,7 +53,7 @@ importers:
     dependencies:
       isomorphic-unfetch: 3.1.0
     devDependencies:
-      '@pokt-foundation/pocketjs-types': 0.0.0
+      '@pokt-foundation/pocketjs-types': link:../types
       '@types/jest': 27.4.0
       '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f
       '@typescript-eslint/parser': 5.10.2_eslint@7.32.0+typescript@4.5.5
@@ -1776,10 +1776,6 @@ packages:
       tslib: 2.3.1
       webcrypto-core: 1.4.0
     dev: false
-
-  /@pokt-foundation/pocketjs-types/0.0.0:
-    resolution: {integrity: sha512-RQ5Jsmwv0UyIS5iuSWaMW2xOts6OnqAqrurPPJghDEK+9sJt1/BzPR1QOSP/qjg9kWwtvf3KeHREn0tYjzZcPg==}
-    dev: true
 
   /@pokt-foundation/pocketjs-utils/0.0.0:
     resolution: {integrity: sha512-zyPRqDPcUyzEGTsxPd7LPuHPpFq6AcUZ0KCyb+s66i/w93jKA8h6XSC++4XTAShUkDq0bJigteIXRFjKbLKPCg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,10 +83,10 @@ importers:
     dependencies:
       '@pokt-foundation/pocketjs-provider': link:../provider
       '@pokt-foundation/pocketjs-signer': link:../signer
-      '@pokt-foundation/pocketjs-types': link:../types
       js-sha256: 0.9.0
       js-sha3: 0.8.0
     devDependencies:
+      '@pokt-foundation/pocketjs-types': link:../types
       '@types/jest': 27.4.0
       '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f
       '@typescript-eslint/parser': 5.10.2_eslint@7.32.0+typescript@4.5.5
@@ -117,11 +117,11 @@ importers:
     dependencies:
       '@noble/ed25519': 1.5.3
       '@pokt-foundation/pocketjs-provider': link:../provider
-      '@pokt-foundation/pocketjs-types': link:../types
       '@pokt-foundation/pocketjs-utils': link:../utils
       hex-lite: 1.5.0
       libsodium-wrappers: 0.7.9
     devDependencies:
+      '@pokt-foundation/pocketjs-types': link:../types
       '@types/jest': 27.4.0
       '@typescript-eslint/eslint-plugin': 5.10.2_3e19df30e549eb9672c3b79dc40c1d5f
       '@typescript-eslint/parser': 5.10.2_eslint@7.32.0+typescript@4.5.5


### PR DESCRIPTION
Fixes random broken builds by just using the most up-to-date version in the workspace instead of hard-linked versions.