### PR TITLE
Signer, Relayer: Fix typing issues

### DIFF
--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -15,7 +15,7 @@
     "build": "microbundle",
     "dev": "microbundle watch"
   },
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "keywords": [],
   "author": "",
   "license": "MIT",

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -20,7 +20,7 @@ import {
 const DEFAULT_RELAYER_TIMEOUT = 5000
 
 export class Relayer implements AbstractRelayer {
-  readonly keyManager: KeyManager | AbstractSigner
+  readonly keyManager: KeyManager
   readonly provider: JsonRpcProvider
   readonly dispatchers: string[]
 

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -15,7 +15,7 @@
     "build": "microbundle",
     "dev": "microbundle watch"
   },
-  "types": "dist/index.d.ts",
+  "types": "dist/src/index.d.ts",
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/packages/signer/tsconfig.json
+++ b/packages/signer/tsconfig.json
@@ -8,7 +8,11 @@
     "declaration": true,
     "declarationDir": "dist"
   },
-  "references": [{ "path": "../provider" }, { "path": "../utils" }],
+  "references": [
+    { "path": "../provider" },
+    { "path": "../utils" },
+    { "path": "../types" }
+  ],
   "include": ["src"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Both of these packages weren't detecting their types properly.