### PR TITLE
Provider, Relayer: Add `blockHeight` to session

### DIFF
--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -408,10 +408,10 @@ export class JsonRpcProvider implements AbstractProvider {
       return {
         blockHeight,
         session: {
-          header: formattedHeader,
-          nodes: formattedNodes,
-          key,
           blockHeight,
+          header: formattedHeader,
+          key,
+          nodes: formattedNodes,
         },
       }
     } catch (err: any) {

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -411,6 +411,7 @@ export class JsonRpcProvider implements AbstractProvider {
           header: formattedHeader,
           nodes: formattedNodes,
           key,
+          blockHeight,
         },
       }
     } catch (err: any) {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,6 +72,7 @@ export interface PocketAAT {
 }
 
 export interface Session {
+  readonly blockHeight: number
   readonly header: SessionHeader
   readonly key: string
   readonly nodes: Node[]


### PR DESCRIPTION
Adds the block height to the dispatch response/session.