### PR TITLE
JSONRPCProvider: Switch to Undici

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@pokt-foundation/pocketjs-abstract-provider": "workspace:*",
-    "isomorphic-unfetch": "^3.1.0"
+    "isomorphic-unfetch": "^3.1.0",
+    "undici": "^5.0.0"
   }
 }

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -1,4 +1,4 @@
-import fetch from 'isomorphic-unfetch'
+import { fetch, Response } from 'undici'
 import {
   Account,
   AccountWithTransactions,
@@ -101,7 +101,7 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryBalance,
       body: { address: await address },
     })
-    const { balance } = await res.json()
+    const { balance } = (await res.json()) as { balance: bigint }
     return balance as bigint
   }
 
@@ -112,7 +112,7 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryAccountTxs,
       body: { address: await address },
     })
-    const txs = await txsRes.json()
+    const txs = (await txsRes.json()) as any
 
     if (!('total_count' in txs)) {
       throw new Error('RPC Error')
@@ -134,8 +134,8 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryNode,
       body: { address: await address },
     })
-    const node = await nodeRes.json()
-    const app = await appRes.json()
+    const node = (await nodeRes.json()) as any
+    const app = (await appRes.json()) as any
 
     if (!('service_url' in node) && 'max_relays' in app) {
       return 'app'
@@ -158,7 +158,7 @@ export class JsonRpcProvider implements AbstractProvider {
       body: { address: await signerAddress, txHex: await signedTransaction },
     })
 
-    const transactionResponse = await res.json()
+    const transactionResponse = (await res.json()) as TransactionResponse
 
     if (!('hash' in transactionResponse)) {
       throw new Error('RPC Error')
@@ -174,7 +174,7 @@ export class JsonRpcProvider implements AbstractProvider {
       body: { height: blockNumber },
     })
 
-    const block = await res.json()
+    const block = (await res.json()) as Block
 
     if (!('block' in block)) {
       throw new Error('RPC Error')
@@ -189,7 +189,7 @@ export class JsonRpcProvider implements AbstractProvider {
       body: { hash: transactionHash },
     })
 
-    const tx = await res.json()
+    const tx = (await res.json()) as TransactionResponse
 
     if (!('hash' in tx)) {
       throw new Error('RPC Error')
@@ -204,7 +204,7 @@ export class JsonRpcProvider implements AbstractProvider {
       body: {},
     })
 
-    const { height } = await res.json()
+    const { height } = (await res.json()) as { height: number }
 
     if (!height) {
       throw new Error('RPC Error')
@@ -225,7 +225,7 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryNode,
       body: { address: await address },
     })
-    const node = await res.json()
+    const node = (await res.json()) as any
 
     if (!('chains' in node)) {
       throw new Error('RPC Error')
@@ -250,7 +250,7 @@ export class JsonRpcProvider implements AbstractProvider {
       stakedTokens: tokens.toString(),
       status,
       unstakingTime: unstaking_time,
-    }
+    } as Node
   }
 
   getApps(getAppOption: GetAppOptions): Promise<App[]> {
@@ -265,7 +265,7 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryApp,
       body: { address: await address },
     })
-    const app = await res.json()
+    const app = (await res.json()) as any
 
     if (!('chains' in app)) {
       throw new Error('RPC Error')
@@ -282,7 +282,7 @@ export class JsonRpcProvider implements AbstractProvider {
       maxRelays: max_relays ?? 0,
       stakedTokens: staked_tokens ?? 0,
       status,
-    }
+    } as App
   }
 
   async getAccount(address: string | Promise<string>): Promise<Account> {
@@ -290,7 +290,7 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryAccount,
       body: { address: await address },
     })
-    const account = await res.json()
+    const account = (await res.json()) as any
 
     if (!('address' in account)) {
       throw new Error('RPC Error')
@@ -316,8 +316,8 @@ export class JsonRpcProvider implements AbstractProvider {
       route: V1RpcRoutes.QueryAccountTxs,
       body: { address: await address },
     })
-    const account = await accountRes.json()
-    const txs = await txsRes.json()
+    const account = (await accountRes.json()) as any
+    const txs = (await txsRes.json()) as any
 
     if (!('address' in account)) {
       throw new Error('RPC Error')
@@ -366,7 +366,7 @@ export class JsonRpcProvider implements AbstractProvider {
         retryAttempts: options.retryAttempts,
       })
 
-      const dispatch = await dispatchRes.json()
+      const dispatch = (await dispatchRes.json()) as any
 
       if (!('session' in dispatch)) {
         throw new Error('RPC Error')

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,9 +75,11 @@ importers:
       prettier: ^2.5.1
       ts-jest: ^27.1.3
       typescript: ^4.5.5
+      undici: ^5.0.0
     dependencies:
       '@pokt-foundation/pocketjs-abstract-provider': link:../abstract-provider
       isomorphic-unfetch: 3.1.0
+      undici: 5.0.0
     devDependencies:
       '@pokt-foundation/pocketjs-types': link:../types
       '@types/jest': 27.4.0
@@ -6486,6 +6488,11 @@ packages:
       has-symbols: 1.0.2
       which-boxed-primitive: 1.0.2
     dev: true
+
+  /undici/5.0.0:
+    resolution: {integrity: sha512-VhUpiZ3No1DOPPQVQnsDZyfcbTTcHdcgWej1PdFnSvOeJmOVDgiOHkunJmBLfmjt4CqgPQddPVjSWW0dsTs5Yg==}
+    engines: {node: '>=12.18'}
+    dev: false
 
   /unfetch/4.2.0:
     resolution: {integrity: sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA==}


### PR DESCRIPTION
Switches to Undici, leaving behind `isomorphic-unfetch` which will be implemented in another package to let browser users use this isomorphic provider, as Undici is node only.

Note that Undici's fetch is only compatible with Node 16.5+.