### PR TITLE
JSONRPCProvider, Relayer: Tighten timeouts & strengthen timeout API

### DIFF
--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@pokt-foundation/pocketjs-abstract-provider": "workspace:*",
+    "abort-controller": "^3.0.0",
     "isomorphic-unfetch": "^3.1.0",
     "undici": "^5.0.0"
   }

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -1,3 +1,4 @@
+import AbortController from 'abort-controller'
 import { fetch, Response } from 'undici'
 import {
   Account,
@@ -76,7 +77,7 @@ export class JsonRpcProvider implements AbstractProvider {
 
     const rpcResponse = await fetch(`${finalRpcUrl}${route}`, {
       method: 'POST',
-      signal: controller.signal,
+      signal: controller.signal as AbortSignal,
       headers: {
         'Content-Type': 'application/json',
       },

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -20,7 +20,7 @@ import {
 } from './errors'
 import { V1RpcRoutes } from './routes'
 
-const DEFAULT_TIMEOUT = 5000
+const DEFAULT_TIMEOUT = 1000
 
 export class JsonRpcProvider implements AbstractProvider {
   private rpcUrl: string
@@ -347,7 +347,7 @@ export class JsonRpcProvider implements AbstractProvider {
     } = {
       retryAttempts: 0,
       rejectSelfSignedCertificates: false,
-      timeout: 5000,
+      timeout: DEFAULT_TIMEOUT,
     }
   ): Promise<DispatchResponse> {
     if (!this.dispatchers.length) {
@@ -432,7 +432,7 @@ export class JsonRpcProvider implements AbstractProvider {
     } = {
       retryAttempts: 0,
       rejectSelfSignedCertificates: false,
-      timeout: 5000,
+      timeout: DEFAULT_TIMEOUT,
     }
   ): Promise<unknown> {
     try {

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -348,7 +348,6 @@ export class JsonRpcProvider implements AbstractProvider {
     } = {
       retryAttempts: 0,
       rejectSelfSignedCertificates: false,
-      timeout: DEFAULT_TIMEOUT,
     }
   ): Promise<DispatchResponse> {
     if (!this.dispatchers.length) {
@@ -363,8 +362,7 @@ export class JsonRpcProvider implements AbstractProvider {
           chain: request.sessionHeader.chain,
           session_height: request.sessionHeader.sessionBlockHeight,
         },
-        timeout: options.timeout,
-        retryAttempts: options.retryAttempts,
+        ...options
       })
 
       const dispatch = (await dispatchRes.json()) as any
@@ -433,7 +431,6 @@ export class JsonRpcProvider implements AbstractProvider {
     } = {
       retryAttempts: 0,
       rejectSelfSignedCertificates: false,
-      timeout: DEFAULT_TIMEOUT,
     }
   ): Promise<unknown> {
     try {
@@ -441,8 +438,7 @@ export class JsonRpcProvider implements AbstractProvider {
         route: V1RpcRoutes.ClientRelay,
         body: request,
         rpcUrl,
-        timeout: options.timeout,
-        retryAttempts: options.retryAttempts,
+        ...options,
       })
 
       const relayResponse = await relayAttempt.json()

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -17,8 +17,6 @@ import {
   validateRelayResponse,
 } from './errors'
 
-const DEFAULT_RELAYER_TIMEOUT = 5000
-
 export class Relayer implements AbstractRelayer {
   readonly keyManager: KeyManager
   readonly provider: JsonRpcProvider
@@ -37,7 +35,6 @@ export class Relayer implements AbstractRelayer {
     options = {
       retryAttempts: 3,
       rejectSelfSignedCertificates: false,
-      timeout: 5000,
     },
   }: {
     applicationPubKey?: string
@@ -78,7 +75,6 @@ export class Relayer implements AbstractRelayer {
     options = {
       retryAttempts: 0,
       rejectSelfSignedCertificates: false,
-      timeout: DEFAULT_RELAYER_TIMEOUT,
     },
   }: {
     blockchain: string
@@ -169,10 +165,7 @@ export class Relayer implements AbstractRelayer {
     const relay = await provider.relay(
       relayRequest,
       serviceNode.serviceUrl.toString(),
-      {
-        timeout: options.timeout,
-        retryAttempts: options.retryAttempts,
-      }
+      options
     )
 
     const relayResponse = await validateRelayResponse(relay)
@@ -209,7 +202,6 @@ export class Relayer implements AbstractRelayer {
     options = {
       retryAttempts: 0,
       rejectSelfSignedCertificates: false,
-      timeout: DEFAULT_RELAYER_TIMEOUT,
     },
   }: {
     data: string

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,7 @@ importers:
       '@types/jest': ^27.4.0
       '@typescript-eslint/eslint-plugin': ^5.10.2
       '@typescript-eslint/parser': ^5.10.2
+      abort-controller: ^3.0.0
       eslint: 7.32.0
       isomorphic-unfetch: ^3.1.0
       jest: ^27.4.7
@@ -78,6 +79,7 @@ importers:
       undici: ^5.0.0
     dependencies:
       '@pokt-foundation/pocketjs-abstract-provider': link:../abstract-provider
+      abort-controller: 3.0.0
       isomorphic-unfetch: 3.1.0
       undici: 5.0.0
     devDependencies:
@@ -2259,6 +2261,13 @@ packages:
     resolution: {integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==}
     dev: true
 
+  /abort-controller/3.0.0:
+    resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
+    engines: {node: '>=6.5'}
+    dependencies:
+      event-target-shim: 5.0.1
+    dev: false
+
   /acorn-globals/6.0.0:
     resolution: {integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==}
     dependencies:
@@ -3351,6 +3360,11 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
     dev: true
+
+  /event-target-shim/5.0.1:
+    resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
+    engines: {node: '>=6'}
+    dev: false
 
   /eventemitter3/4.0.7:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}


### PR DESCRIPTION
To make sure that no matter the node version timeouts still work as expected, we're adding the `abort-controller` package directly so it polyfills the class if the node version is lower than 15. Apart from this, a few things were tightened on the timeout API, mainly the way they're passed in, to avoid any bugs.