### PR TITLE
TransactionBuilder: expose lib internals with `AbstractBuilder`

### DIFF
--- a/packages/transaction-builder/src/abstract-tx-builder.ts
+++ b/packages/transaction-builder/src/abstract-tx-builder.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'buffer'
 import {
   MsgProtoAppStake,
   MsgProtoAppUnstake,
@@ -7,75 +6,26 @@ import {
   MsgProtoNodeUnstake,
   MsgProtoSend,
 } from './models/msgs'
-import { AbstractProvider } from '@pokt-foundation/pocketjs-abstract-provider'
-import { KeyManager } from '@pokt-foundation/pocketjs-signer'
 import {
   RawTxRequest,
   TransactionResponse,
 } from '@pokt-foundation/pocketjs-types'
-import { TxEncoderFactory } from './factory/tx-encoder-factory'
-import { CoinDenom, TxMsg, TxSignature } from './models/'
-import { InvalidChainIDError, NoProviderError, NoSignerError } from './errors'
-import {AbstractBuilder} from './abstract-tx-builder'
+import { TxMsg } from './models/'
 
 export type ChainID = 'mainnet' | 'testnet' | 'localnet'
 
-// Default Pocket Base fee.
-// Using anything above 10k uPOKT means overpaying--there is no reason to do so,
-// as the chain is merely focused on utility. No profit is gained by ordering txs
-// in a block in a certain way.
-export const DEFAULT_BASE_FEE = '10000'
-
-/**
- * A Transaction builder lets you create transaction messages, sign them, and send them over the network.
- * Requires a properly initialized Provider and Signer to work.
- */
-export class TransactionBuilder implements AbstractBuilder {
-  private provider: AbstractProvider
-  private signer: KeyManager
-  private chainID: ChainID
-
-  constructor({
-    provider,
-    signer,
-    chainID = 'mainnet',
-  }: {
-    provider: AbstractProvider
-    signer: KeyManager
-    chainID: ChainID
-  }) {
-    if (!provider) {
-      throw new NoProviderError('Please add a provider.')
-    }
-    if (!signer) {
-      throw new NoSignerError('Please add a signer.')
-    }
-
-    this.provider = provider
-    this.signer = signer
-    this.chainID = chainID
-  }
-
+export abstract class AbstractBuilder {
   /**
    * Gets the current chain ID this Transaction Builder has been initialized for.
    * @returns {ChainID} - 'mainnet', 'localnet', or 'testnet'.
    */
-  public getChainID(): ChainID {
-    return this.chainID
-  }
+  abstract getChainID(): ChainID
 
   /**
    * Sets the chainID to one of the supported networks.
    */
-  public setChainID(id: ChainID): void {
-    if (id === 'mainnet' || id === 'testnet' || id === 'localnet') {
-      this.chainID = id
-    } else {
-      throw new InvalidChainIDError(
-        `Invalid ChainID. Must be "mainnet", "testnet", or "localnet".`
-      )
-    }
-  }
+  abstract setChainID(id: ChainID): void
+
   /**
    * Signs and creates a transaction object that can be submitted to the network given the parameters and called upon Msgs.
    * Will empty the msg list after succesful creation
@@ -83,46 +33,15 @@ export class TransactionBuilder implements AbstractBuilder {
    * @param {string} memo - The memo field for this account
    * @returns {Promise<RawTxRequest>} - A Raw transaction Request which can be sent over the network.
    */
-  public async createTransaction({
-    fee = DEFAULT_BASE_FEE,
-    memo = '',
+  abstract createTransaction({
+    fee,
+    memo,
     txMsg,
   }: {
     fee?: string | bigint
     memo?: string
     txMsg: TxMsg
-  }): Promise<RawTxRequest> {
-    // Let's make sure txMsg is defined.
-    if (!txMsg) {
-      throw new Error('txMsg should be defined.')
-    }
-
-    const entropy = Number(
-      BigInt(Math.floor(Math.random() * Number.MAX_SAFE_INTEGER)).toString()
-    ).toString()
-
-    const signer = TxEncoderFactory.createEncoder(
-      entropy,
-      this.chainID,
-      txMsg,
-      fee.toString(),
-      CoinDenom.Upokt,
-      memo
-    )
-
-    const bytesToSign = signer.marshalStdSignDoc()
-
-    const txBytes = await this.signer.sign(bytesToSign.toString('hex'))
-
-    const marshalledTx = new TxSignature(
-      Buffer.from(this.signer.getPublicKey(), 'hex'),
-      Buffer.from(txBytes, 'hex')
-    )
-
-    const rawHexBytes = signer.marshalStdTx(marshalledTx).toString('hex')
-
-    return new RawTxRequest(this.signer.getAddress(), rawHexBytes)
-  }
+  }): Promise<RawTxRequest>
 
   /**
    * Submit receives a valid transaction message, creates a Raw Transaction Request and sends it over the network.
@@ -131,30 +50,22 @@ export class TransactionBuilder implements AbstractBuilder {
    * @param {TxMsg} txMsg - The transaction message to use for creating the RawTxRequest that will be sent over the network.
    * @returns {Promise<TransactionResponse>} - The Transaction Response from the network, containing the transaction hash.
    */
-  public async submit({
-    fee = DEFAULT_BASE_FEE,
-    memo = '',
+  abstract submit({
+    fee,
+    memo,
     txMsg,
   }: {
     fee?: string | bigint
     memo?: string
     txMsg: TxMsg
-  }): Promise<TransactionResponse> {
-    const tx = await this.createTransaction({ fee, memo, txMsg })
-
-    return await this.provider.sendTransaction(tx)
-  }
+  }): Promise<TransactionResponse>
 
   /**
    * Submit receives an already made Raw Transaction Request and sends it over the network.
    * @param {RawTxRequest} tx - The Raw Transaction Request use for creating the RawTxRequest that will be sent over the network.
    * @returns {Promise<TransactionResponse>} - The Transaction Response from the network, containing the transaction hash.
    */
-  public async submitRawTransaction(
-    tx: RawTxRequest
-  ): Promise<TransactionResponse> {
-    return await this.provider.sendTransaction(tx)
-  }
+  abstract submitRawTransaction(tx: RawTxRequest): Promise<TransactionResponse>
 
   /**
    * Adds a MsgSend TxMsg for this transaction
@@ -163,13 +74,11 @@ export class TransactionBuilder implements AbstractBuilder {
    * @param {string} amount - Amount to be sent, needs to be a valid number greater than 1 uPOKT.
    * @returns {MsgProtoSend} - The unsigned Send message.
    */
-  public send(
+  abstract send(
     fromAddress: string,
     toAddress: string,
     amount: string
-  ): MsgProtoSend {
-    return new MsgProtoSend(fromAddress, toAddress, amount)
-  }
+  ): MsgProtoSend
 
   /**
    * Adds a MsgAppStake TxMsg for this transaction
@@ -178,22 +87,18 @@ export class TransactionBuilder implements AbstractBuilder {
    * @param {string} amount - the amount to stake, must be greater than or equal to 1 POKT
    * @returns {MsgProtoAppStake} - The unsigned App Stake message.
    */
-  public appStake(
+  abstract appStake(
     appPubKey: string,
     chains: string[],
     amount: string
-  ): MsgProtoAppStake {
-    return new MsgProtoAppStake(appPubKey, chains, amount)
-  }
+  ): MsgProtoAppStake
 
   /**
    * Adds a MsgBeginAppUnstake TxMsg for this transaction
    * @param {string} address - Address of the Application to unstake for
    * @returns {MsgProtoAppUnstake} - The unsigned App Unstake message.
    */
-  public appUnstake(address: string): MsgProtoAppUnstake {
-    return new MsgProtoAppUnstake(address)
-  }
+  abstract appUnstake(address: string): MsgProtoAppUnstake
 
   /**
    * Adds a NodeStake TxMsg for this transaction
@@ -203,30 +108,24 @@ export class TransactionBuilder implements AbstractBuilder {
    * @param {URL} serviceURL - Node service url
    * @returns {MsgProtoNodeStakeTx} - The unsigned Node Stake message.
    */
-  public nodeStake(
+  abstract nodeStake(
     nodePubKey: string,
     chains: string[],
     amount: string,
     serviceURL: URL
-  ): MsgProtoNodeStakeTx {
-    return new MsgProtoNodeStakeTx(nodePubKey, chains, amount, serviceURL)
-  }
+  ): MsgProtoNodeStakeTx
 
   /**
    * Adds a MsgBeginUnstake TxMsg for this transaction
    * @param {string} address - Address of the Node to unstake for
    * @returns {MsgProtoNodeUnstake} - The unsigned Node Unstake message.
    */
-  public nodeUnstake(address: string): MsgProtoNodeUnstake {
-    return new MsgProtoNodeUnstake(address)
-  }
+  abstract nodeUnstake(address: string): MsgProtoNodeUnstake
 
   /**
    * Adds a MsgUnjail TxMsg for this transaction
    * @param {string} address - Address of the Node to unjail
    * @returns {MsgProtoNodeUnjail} - The unsigned Node Unjail message.
    */
-  public nodeUnjail(address: string): MsgProtoNodeUnjail {
-    return new MsgProtoNodeUnjail(address)
-  }
+  abstract nodeUnjail(address: string): MsgProtoNodeUnjail
 }

--- a/packages/transaction-builder/src/index.ts
+++ b/packages/transaction-builder/src/index.ts
@@ -1,1 +1,4 @@
 export * from './tx-builder'
+export * from './errors'
+export * from './models'
+export * from './factory'


### PR DESCRIPTION
Adds an interface usable by people that might wanna implement their own `TransactionBuilder`s—community members with special platform needs might find it useful.