### PR TITLE
`TransactionBuilder`: Stringify encoded messages with `Buffer.from`

### DIFF
--- a/packages/transaction-builder/src/models/msgs/msg-proto-app-stake.ts
+++ b/packages/transaction-builder/src/models/msgs/msg-proto-app-stake.ts
@@ -32,7 +32,9 @@ export class MsgProtoAppStake extends TxMsg {
     if (isNaN(amountNumber)) {
       throw new Error('Amount is not a valid number')
     } else if (amountNumber < MINIMUM_STAKE_AMOUNT) {
-      throw new Error('Amount should be bigger than ${MINIMUM_STAKE_AMOUNT} uPOKT')
+      throw new Error(
+        'Amount should be bigger than ${MINIMUM_STAKE_AMOUNT} uPOKT'
+      )
     } else if (this.chains.length === 0) {
       throw new Error('Chains is empty')
     }
@@ -80,7 +82,9 @@ export class MsgProtoAppStake extends TxMsg {
 
     return Any.fromJSON({
       typeUrl: this.KEY,
-      value: MsgProtoStake.encode(data).finish().toString('base64'),
+      value: Buffer.from(MsgProtoStake.encode(data).finish()).toString(
+        'base64'
+      ),
     })
   }
 }

--- a/packages/transaction-builder/src/models/msgs/msg-proto-app-unjail.ts
+++ b/packages/transaction-builder/src/models/msgs/msg-proto-app-unjail.ts
@@ -44,7 +44,7 @@ export class MsgProtoAppUnjail extends TxMsg {
 
     return Any.fromJSON({
       typeUrl: this.KEY,
-      value: MsgUnjail.encode(data).finish().toString('base64'),
+      value: Buffer.from(MsgUnjail.encode(data).finish()).toString('base64'),
     })
   }
 }

--- a/packages/transaction-builder/src/models/msgs/msg-proto-app-unstake.ts
+++ b/packages/transaction-builder/src/models/msgs/msg-proto-app-unstake.ts
@@ -43,7 +43,9 @@ export class MsgProtoAppUnstake extends TxMsg {
 
     return Any.fromJSON({
       typeUrl: this.KEY,
-      value: MsgBeginUnstake.encode(data).finish().toString('base64'),
+      value: Buffer.from(MsgBeginUnstake.encode(data).finish()).toString(
+        'base64'
+      ),
     })
   }
 }

--- a/packages/transaction-builder/src/models/msgs/msg-proto-node-stake.ts
+++ b/packages/transaction-builder/src/models/msgs/msg-proto-node-stake.ts
@@ -103,7 +103,9 @@ export class MsgProtoNodeStakeTx extends TxMsg {
 
     return Any.fromJSON({
       typeUrl: this.KEY,
-      value: MsgProtoNodeStake.encode(data).finish().toString('base64'),
+      value: Buffer.from(MsgProtoNodeStake.encode(data).finish()).toString(
+        'base64'
+      ),
     })
   }
 }


### PR DESCRIPTION
This is a bit of an annoying issue and doesn't really cause a problem, but due to the new tx signer & buffer polyfill we're using we now need to convert the encoded messages with `Buffer.from` before converting them to base64. Fixes #54 