### PR TITLE
 fix: npm release with proper workspace dependencies

### DIFF
--- a/packages/abstract-provider/package.json
+++ b/packages/abstract-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-abstract-provider",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Abstract provider for all other providers to inherit",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/isomorphic-provider/package.json
+++ b/packages/isomorphic-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-isomorphic-provider",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-provider",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/relayer/package.json
+++ b/packages/relayer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-relayer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Slim relayer client for the Pocket Network v0 Protocol",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-signer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Signer for Pocket Network V0 accounts",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/transaction-builder/package.json
+++ b/packages/transaction-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-transaction-builder",
-  "version": "1.1.0",
+  "version": "1.1.1-alpha",
   "description": "Transaction manager and utilties for the Pocket Network protocol",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-types",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "PocketJS types",
   "type": "module",
   "source": "src/index.ts",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pokt-foundation/pocketjs-utils",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Utilities used across pocket-js",
   "type": "module",
   "source": "src/index.ts",


### PR DESCRIPTION
Release v1.1.0 had some issues with the workspace packages dependencies when it was published. This PR bumps the version so it can be re-released with proper workspace dependencies.