### PR TITLE
fix: prevent raw npm publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.3",
   "scripts": {
     "build": "turbo run build",
+    "release": "RELEASE_MODE=true pnpm publish",
     "build:abstract-provider": "turbo run build --scope=*abstract-provider* --no-deps",
     "build:pocket": "turbo run build --scope=@pokt-foundation/pocketjs --no-deps",
     "build:provider": "turbo run build --scope=*provider* --no-deps",
@@ -22,7 +23,8 @@
     "dev:utils": "turbo run dev --scope=*utils* --no-cache --no-deps",
     "lint": "turbo run lint",
     "test": "turbo run test",
-    "format": "prettier --write \"**/*.{ts,tsx,md}\""
+    "format": "prettier --write \"**/*.{ts,tsx,md}\"",
+    "prepublishOnly": "node ./scripts/prepublish.js"
   },
   "devDependencies": {
     "prettier": "^2.5.1",

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,6 +1,6 @@
 const RELEASE_MODE = !!process.env.RELEASE_MODE;
 
 if (!RELEASE_MODE) {
-  console.log("Run `npm run release` to publish the package");
+  console.log("Run `npm run release` or `pnpm publish` to publish the package");
   process.exit(1); //which terminates the publish process
 }

--- a/scripts/prepublish.js
+++ b/scripts/prepublish.js
@@ -1,0 +1,6 @@
+const RELEASE_MODE = !!process.env.RELEASE_MODE;
+
+if (!RELEASE_MODE) {
+  console.log("Run `npm run release` to publish the package");
+  process.exit(1); //which terminates the publish process
+}


### PR DESCRIPTION
As we are using PNPM as our package manager, we need to always publish using `pnpm publish`. If it was published with `npm publish` it would cause a dependency error (see v1.1.0). 

This PR introduces a prepublish script to prevent direct `npm publish` commands.