### PR TITLE
Increase timeout for providers

### DIFF
--- a/packages/isomorphic-provider/src/index.ts
+++ b/packages/isomorphic-provider/src/index.ts
@@ -31,7 +31,7 @@ import {
   V1RpcRoutes,
 } from '@pokt-foundation/pocketjs-abstract-provider'
 
-const DEFAULT_TIMEOUT = 1000
+const DEFAULT_TIMEOUT = 3000
 
 /**
  * An IsomorphicProvider lets you query data from the chain and send relays to the network.

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -32,7 +32,7 @@ import {
   V1RpcRoutes,
 } from '@pokt-foundation/pocketjs-abstract-provider'
 
-const DEFAULT_TIMEOUT = 1000
+const DEFAULT_TIMEOUT = 3000
 
 /**
  * A JSONRPCProvider lets you query data from the chain and send relays to the network.


### PR DESCRIPTION
Tackles https://github.com/pokt-foundation/pocket-js/issues/75 in a naive way by increasing timeout from 1s to 3s.

```js
AbortError: The user aborted a request.
```
is still common despite good internet speeds (300Mbps)

May not be ideal for dependencies i.e Portal who uses it for relaying, not sure.jpg