### PR TITLE
Increase default timeout

### DIFF
--- a/packages/isomorphic-provider/src/index.ts
+++ b/packages/isomorphic-provider/src/index.ts
@@ -32,7 +32,7 @@ import {
 } from '@pokt-foundation/pocketjs-abstract-provider'
 import { hrtime } from '@pokt-foundation/pocketjs-utils'
 
-const DEFAULT_TIMEOUT = 1000
+const DEFAULT_TIMEOUT = 10000
 
 /**
  * An IsomorphicProvider lets you query data from the chain and send relays to the network.

--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -32,7 +32,7 @@ import {
   V1RpcRoutes,
 } from '@pokt-foundation/pocketjs-abstract-provider'
 
-const DEFAULT_TIMEOUT = 1000
+const DEFAULT_TIMEOUT = 10000
 
 /**
  * A JSONRPCProvider lets you query data from the chain and send relays to the network.


### PR DESCRIPTION
During application development, we ran into issues with random errors and timeouts. The issue was determined to be the low default timeout value (1,000ms). Increasing this value to 10,000ms is in line with other common well-known libraries and has resolved the issue. 