### PR TITLE
Relayer: Introduce Relayer.GenerateAAT

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ import {
   MAINNET_RPC_URL,
   DISPATCHERS,
   RELAY_DATA,
-  POCKET_AAT,
 } from "./config.js";
 
 // Instantiate a provider for querying information on the chain!
@@ -53,7 +52,7 @@ export const transactionBuilder = new TransactionBuilder({
 
 // Create a new `Send` Message which is used to send funds over the network.
 const sendMsg = transactionBuilder.send(
-  signer.getAddress(), 
+  signer.getAddress(),
   "07a6fca4dea9f01e4c19f301df0d0afac128561b",
   // Amount in uPOKT (1 POKT = 1*10^6 uPOKT)
   "1000000"
@@ -76,10 +75,14 @@ const session = await relayer.getNewSession({
   applicationPubKey: process.env.APP_PUBLIC_KEY,
 });
 
+const appSigner = await KeyManager.fromPrivateKey(process.env.APP_PRIVATE_KEY);
+const clientSigner = await KeyManager.createRandom();
+const aat = await Relayer.GenerateAAT(appSigner, clientSigner.publicKey);
+
 const relay = await relayer.relay({
   data: process.env.RELAY_DATA,
   blockchain: process.env.APP_CHAIN,
-  pocketAAT: POCKET_AAT,
+  pocketAAT: aat,
   session: session,
 });
 ```

--- a/packages/relayer/src/relayer.ts
+++ b/packages/relayer/src/relayer.ts
@@ -358,4 +358,19 @@ export class Relayer implements AbstractRelayer {
     max = Math.floor(max)
     return Math.floor(randomNumber * (max - min + 1)) + min
   }
+
+  static async GenerateAAT(
+    applicationPrivKey: KeyManager,
+    clientPubKey: string,
+  ): Promise<PocketAAT> {
+    const aat = {
+        version: "0.0.1",
+        applicationPublicKey: applicationPrivKey.getPublicKey(),
+        clientPublicKey: clientPubKey,
+        applicationSignature: "",
+    };
+    const hash = this.hashAAT(aat);
+    aat.applicationSignature = await applicationPrivKey.sign(hash);
+    return aat;
+  }
 }


### PR DESCRIPTION
This patch introduces a method to generate an AAT.  Here's an example to generate an AAT from the private key of a staked app, which can be passed to `Relayer.relay` for example.

```js
const AppSigner = await KeyManager.fromPrivateKey(process.env.APP_PRIVATE_KEY);
const ClientSigner = await KeyManager.createRandom();
const AAT = await Relayer.GenerateAAT(AppSigner, ClientSigner.publicKey);
```