### PR TITLE
Signer: Remove unnecessary dependencies

### DIFF
--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -34,8 +34,6 @@
   },
   "dependencies": {
     "@noble/ed25519": "^1.5.3",
-    "@pokt-foundation/pocketjs-abstract-provider": "workspace:*",
-    "@pokt-foundation/pocketjs-provider": "workspace:*",
     "@pokt-foundation/pocketjs-utils": "workspace:*",
     "buffer": "^6.0.3",
     "debug": "^4.3.3",


### PR DESCRIPTION
This patch removes unnecessary dependent modules from the `pocketjs-signer` package.