### PR TITLE
TxBuilder: Introduce TransactionBuilder.appTransfer

### DIFF
--- a/packages/transaction-builder/README.md
+++ b/packages/transaction-builder/README.md
@@ -137,6 +137,17 @@ Returns a `MsgProtoAppStake`: The unsigned App Stake message.
 | chains    | `string[]` | Chains that the apps wants access to by staking POKT. Throughput will be equally divided through all chains. |
 | amount    | `string`   | Amount of uPOKT to stake.                                                                                    |
 
+#### appTransfer({ appPubKey }): MsgProtoAppStake
+
+Builds a transaction message to transfer the slot of a staked app.
+Signer must be an existing staked app to transfer the slot from.
+
+Returns a `MsgProtoAppTransfer`: The unsigned AppTransfer message
+
+|Param|Type|Description|
+|--|--|--|
+|appPubKey|`string`|Application public key to be transferred to|
+
 #### appUnstake(address): MsgProtoAppUnstake
 
 Adds a MsgProtoAppUnstake TxMsg for this transaction.

--- a/packages/transaction-builder/src/models/msgs/index.ts
+++ b/packages/transaction-builder/src/models/msgs/index.ts
@@ -1,4 +1,5 @@
 export * from './msg-proto-app-stake'
+export * from './msg-proto-app-transfer'
 export * from './msg-proto-app-unstake'
 export * from './msg-proto-node-stake'
 export * from './msg-proto-node-unjail'

--- a/packages/transaction-builder/src/models/msgs/msg-proto-app-transfer.ts
+++ b/packages/transaction-builder/src/models/msgs/msg-proto-app-transfer.ts
@@ -1,0 +1,62 @@
+import { Buffer } from 'buffer'
+import { MsgProtoStake } from '../proto/generated/tx-signer'
+import { Any } from '../proto/generated/google/protobuf/any'
+import { TxMsg } from './tx-msg'
+
+/**
+ * MsgProtoAppTransfer is a special case of MsgProtoAppStake where
+ * chains and amount are not set
+ */
+export class MsgProtoAppTransfer extends TxMsg {
+  public readonly KEY: string = '/x.apps.MsgProtoStake'
+  public readonly AMINO_KEY: string = 'apps/MsgAppStake'
+  public readonly pubKey: Buffer
+
+  /**
+   * Constructor for this class
+   * @param {Buffer} pubKey - Application public key to be transferred to
+   */
+  constructor(pubKey: string) {
+    super()
+    this.pubKey = Buffer.from(pubKey, 'hex')
+  }
+
+  /**
+   * Converts an Msg Object to StdSignDoc
+   * @returns {object} - Msg type key value.
+   * @memberof MsgAppStake
+   */
+  public toStdSignDocMsgObj(): object {
+    return {
+      type: this.AMINO_KEY,
+      value: {
+        chains: null,
+        pubkey: {
+          type: 'crypto/ed25519_public_key',
+          value: this.pubKey.toString('hex'),
+        },
+        value: '0',
+      },
+    }
+  }
+
+  /**
+   * Converts an Msg Object for StdTx encoding
+   * @returns {any} - Msg type key value.
+   * @memberof MsgAppStake
+   */
+  public toStdTxMsgObj(): any {
+    const data : MsgProtoStake = {
+      pubKey: this.pubKey,
+      chains: [],
+      value: '0',
+    }
+
+    return Any.fromJSON({
+      typeUrl: this.KEY,
+      value: Buffer.from(MsgProtoStake.encode(data).finish()).toString(
+        'base64'
+      ),
+    })
+  }
+}

--- a/packages/transaction-builder/src/tx-builder.ts
+++ b/packages/transaction-builder/src/tx-builder.ts
@@ -1,6 +1,7 @@
 import { Buffer } from 'buffer'
 import {
   MsgProtoAppStake,
+  MsgProtoAppTransfer,
   MsgProtoAppUnstake,
   MsgProtoNodeStakeTx,
   MsgProtoNodeUnjail,
@@ -28,7 +29,6 @@ import { InvalidChainIDError, NoProviderError, NoSignerError } from './errors'
 import { AbstractBuilder } from './abstract-tx-builder'
 import { MsgProtoGovDAOTransfer } from './models/msgs/msg-proto-gov-dao-transfer'
 import { MsgProtoGovChangeParam } from './models/msgs/msg-proto-gov-change-param'
-import { Upgrade } from './models/proto/generated/tx-signer'
 import { MsgProtoGovUpgrade } from './models/msgs/msg-proto-gov-upgrade'
 
 export type ChainID = 'mainnet' | 'testnet' | 'localnet'
@@ -205,6 +205,20 @@ export class TransactionBuilder implements AbstractBuilder {
     amount: string
   }): MsgProtoAppStake {
     return new MsgProtoAppStake(appPubKey, chains, amount)
+  }
+
+  /**
+   * Builds a transaction message to transfer the slot of a staked app.
+   * Signer must be an existing staked app to transfer the slot from.
+   * @param {string} appPubKey - Application public key to be transferred to
+   * @returns {MsgProtoAppTransfer} - The unsigned AppTransfer message
+   */
+  public appTransfer({
+    appPubKey,
+  }: {
+    appPubKey: string
+  }): MsgProtoAppTransfer {
+    return new MsgProtoAppTransfer(appPubKey)
   }
 
   /**

--- a/packages/transaction-builder/tests/transactions.test.ts
+++ b/packages/transaction-builder/tests/transactions.test.ts
@@ -18,6 +18,7 @@ import { RawTxRequest } from '@pokt-foundation/pocketjs-types'
 import { MsgProtoGovUpgrade } from '../src/models/msgs/msg-proto-gov-upgrade'
 import { MsgProtoGovChangeParam } from '../src/models/msgs/msg-proto-gov-change-param'
 import { MsgProtoGovDAOTransfer } from '../src/models/msgs/msg-proto-gov-dao-transfer'
+import { MsgProtoAppTransfer } from '../src/models/msgs/msg-proto-app-transfer'
 
 const PRIVATE_KEY =
   '1f8cbde30ef5a9db0a5a9d5eb40536fc9defc318b8581d543808b7504e0902bcb243b27bc9fbe5580457a46370ae5f03a6f6753633e51efdaf2cf534fdc26cc3'
@@ -83,6 +84,11 @@ describe('TransactionBuilder Tests', () => {
         amount: '69420000000',
       })
       expect(appStakeMsg instanceof MsgProtoAppStake).toBe(true)
+
+      const appTransferMsg = transactionBuilder.appTransfer({
+        appPubKey: (await KeyManager.createRandom()).getPublicKey(),
+      })
+      expect(appTransferMsg instanceof MsgProtoAppTransfer).toBe(true)
 
       const appUnstakeMsg = transactionBuilder.appUnstake(ADDRESS)
       expect(appUnstakeMsg instanceof MsgProtoAppUnstake).toBe(true)


### PR DESCRIPTION
This patch implements a new feature AppTransfer ([PIP-35](https://forum.pokt.network/t/pip-35-introduce-a-secure-way-to-transfer-a-staked-app-to-a-new-account/4806); introduced by https://github.com/pokt-network/pocket-core/pull/1585).