### PR TITLE
URL with a path and credentials is not handled correctly

### DIFF
--- a/packages/provider/src/json-rpc-provider.ts
+++ b/packages/provider/src/json-rpc-provider.ts
@@ -36,10 +36,10 @@ import {
 const DEFAULT_TIMEOUT = 10000
 
 /**
- * ExtractBasicAuth extracts basic authentication credentials from the given
+ * extractBasicAuth extracts basic authentication credentials from the given
  * url into a separate base64-encoded string so that we can pass it to Fetch API.
  **/
-export function ExtractBasicAuth(urlStr: string) {
+export function extractBasicAuth(urlStr: string) {
   const url = new URL(urlStr);
   if (!url.username && !url.password) {
     return {
@@ -120,7 +120,7 @@ export class JsonRpcProvider implements AbstractProvider {
       'Content-Type': 'application/json',
     };
 
-    const {urlStr, basicAuth} = ExtractBasicAuth(finalRpcUrl);
+    const {urlStr, basicAuth} = extractBasicAuth(finalRpcUrl);
     if (basicAuth) {
       headers['Authorization'] = basicAuth;
     }

--- a/packages/provider/tests/json-rpc-provider.test.ts
+++ b/packages/provider/tests/json-rpc-provider.test.ts
@@ -1,6 +1,6 @@
 import { MockAgent, setGlobalDispatcher } from 'undici'
 import { DEFAULT_URL } from './test-utils'
-import { JsonRpcProvider } from '../src/json-rpc-provider'
+import { JsonRpcProvider, ExtractBasicAuth } from '../src/json-rpc-provider'
 import { V1RpcRoutes } from '@pokt-foundation/pocketjs-abstract-provider'
 import { responseSamples } from './response-samples'
 import { RawTxRequest } from '@pokt-foundation/pocketjs-types'
@@ -159,5 +159,24 @@ describe('JsonRpcProvider tests', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     expect(ans).toBe(59133)
+  })
+
+  it('ExtractBasicAuth test', () => {
+    let {urlStr, basicAuth} =
+    ExtractBasicAuth('https://localhost:8082');
+    expect(urlStr).toBe('https://localhost:8082');
+    expect(basicAuth).toBeUndefined();
+
+    // Url with a path
+    ({urlStr, basicAuth} =
+      ExtractBasicAuth('https://mainnet.rpc.grove.city/v1/12345678'));
+    expect(urlStr).toBe('https://mainnet.rpc.grove.city/v1/12345678');
+    expect(basicAuth).toBeUndefined();
+
+    // Url with a path and a credential
+    ({urlStr, basicAuth} =
+      ExtractBasicAuth('https://scott:tiger@mainnet.rpc.grove.city/v1/12345678'));
+    expect(urlStr).toBe('https://mainnet.rpc.grove.city/v1/12345678');
+    expect(basicAuth).toBe('Basic c2NvdHQ6dGlnZXI=');
   })
 })

--- a/packages/provider/tests/json-rpc-provider.test.ts
+++ b/packages/provider/tests/json-rpc-provider.test.ts
@@ -1,6 +1,6 @@
 import { MockAgent, setGlobalDispatcher } from 'undici'
 import { DEFAULT_URL } from './test-utils'
-import { JsonRpcProvider, ExtractBasicAuth } from '../src/json-rpc-provider'
+import { JsonRpcProvider, extractBasicAuth } from '../src/json-rpc-provider'
 import { V1RpcRoutes } from '@pokt-foundation/pocketjs-abstract-provider'
 import { responseSamples } from './response-samples'
 import { RawTxRequest } from '@pokt-foundation/pocketjs-types'
@@ -161,21 +161,21 @@ describe('JsonRpcProvider tests', () => {
     expect(ans).toBe(59133)
   })
 
-  it('ExtractBasicAuth test', () => {
+  it('extractBasicAuth test', () => {
     let {urlStr, basicAuth} =
-    ExtractBasicAuth('https://localhost:8082');
+    extractBasicAuth('https://localhost:8082');
     expect(urlStr).toBe('https://localhost:8082');
     expect(basicAuth).toBeUndefined();
 
     // Url with a path
     ({urlStr, basicAuth} =
-      ExtractBasicAuth('https://mainnet.rpc.grove.city/v1/12345678'));
+      extractBasicAuth('https://mainnet.rpc.grove.city/v1/12345678'));
     expect(urlStr).toBe('https://mainnet.rpc.grove.city/v1/12345678');
     expect(basicAuth).toBeUndefined();
 
     // Url with a path and a credential
     ({urlStr, basicAuth} =
-      ExtractBasicAuth('https://scott:tiger@mainnet.rpc.grove.city/v1/12345678'));
+      extractBasicAuth('https://scott:tiger@mainnet.rpc.grove.city/v1/12345678'));
     expect(urlStr).toBe('https://mainnet.rpc.grove.city/v1/12345678');
     expect(basicAuth).toBe('Basic c2NvdHQ6dGlnZXI=');
   })


### PR DESCRIPTION
This is a fix for a regression introduced by 1766e700146ee1d8da5df86b49c00689545849d3.

If a URL with a path is passed to `JsonRpcProvider`, the path is dropped when the provider makes a query because `const url = new URL(route, finalRpcUrl);` does drop the path in `finalRpcUrl`.

The proposed fix to create a URL first, and appends a path via string concat.  This patch also adds a testcase for that logic.