### PR TITLE
Fix TypeScript Typings Resolution for @pokt-foundation/pocketjs-signer

### DIFF
--- a/packages/signer/package.json
+++ b/packages/signer/package.json
@@ -6,7 +6,8 @@
   "source": "src/index.ts",
   "exports": {
     "require": "./dist/index.cjs",
-    "default": "./dist/index.js"
+    "default": "./dist/index.js",
+    "types": "./dist/src/index.d.ts"
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",


### PR DESCRIPTION
If you install the library using the following command:
```
npm i @pokt-foundation/pocketjs-signer
```

And import it into your project like this:
```
import { KeyManager } from "@pokt-foundation/pocketjs-signer";
```

You will get the following error:
```
Could not find a declaration file for module '@pokt-foundation/pocketjs-signer'. '/Users/luis/github/new-wallet/node_modules/@pokt-foundation/pocketjs-signer/dist/index.js' implicitly has an 'any' type.
  There are types at '/Users/luis/github/new-wallet/node_modules/@pokt-foundation/pocketjs-signer/dist/src/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@pokt-foundation/pocketjs-signer' library may need to update its package.json or typings.
  ```
 
  This pull request fixes the issue.